### PR TITLE
Added golang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ executed programm now.
 		
         helloClosure "Bob"
     ```
+- Golang
+    - Requirements: Golang is installed and correct path is set in the settings(`go` binary is available).
+    - Every code block must contain package declaration and a main function.
+```go
+    package main
+
+    import "fmt"
+
+    func main() {
+        fmt.Println("Hello World")
+    }
+```
+
 - Squiggle: For Squiggle support look at the [Obsidian Squiggle plugin](https://github.com/jqhoogland/obsidian-squiggle)
   by @jqhoogland.
 

--- a/SettingsTab.ts
+++ b/SettingsTab.ts
@@ -70,6 +70,19 @@ export class SettingsTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				}));
 
+        // ========== Golang =========
+		containerEl.createEl('h3', {text: 'Golang Settings'});
+		new Setting(containerEl)
+			.setName('Golang Path')
+			.setDesc('The path to your Golang installation.')
+			.addText(text => text
+				.setValue(this.plugin.settings.golangPath)
+				.onChange(async (value) => {
+					this.plugin.settings.golangPath = value;
+					console.log('Golang path set to: ' + value);
+					await this.plugin.saveSettings();
+				}));
+
 		// ========== Python ==========
 		containerEl.createEl('h3', {text: 'Python Settings'});
 		new Setting(containerEl)

--- a/main.ts
+++ b/main.ts
@@ -208,7 +208,7 @@ export default class ExecuteCodePlugin extends Plugin {
 			});
 		} else if (language.contains("language-go")) {
             button.addEventListener("click" , () => {
-                // button.className = runButtonDisabledClass;
+                button.className = runButtonDisabledClass;
 
 				this.runCode(srcCode, out, button, this.settings.golangPath, this.settings.golangArgs, this.settings.golangFileExtension);
             })

--- a/main.ts
+++ b/main.ts
@@ -18,7 +18,7 @@ import * as JSCPP from "JSCPP";
 // @ts-ignore
 import * as prolog from "tau-prolog";
 
-const supportedLanguages = ["js", "javascript", "python", "cpp", "prolog", "shell", "bash", "groovy", "r"];
+const supportedLanguages = ["js", "javascript", "python", "cpp", "prolog", "shell", "bash", "groovy", "r","go"];
 
 const buttonText = "Run";
 
@@ -39,6 +39,9 @@ const DEFAULT_SETTINGS: ExecutorSettings = {
 	groovyPath: "groovy",
 	groovyArgs: "",
 	groovyFileExtension: "groovy",
+    golangPath: "go",
+    golangArgs: "run",
+    golangFileExtension: "go",
 	maxPrologAnswers: 15,
 	RPath: "Rscript",
 	RArgs: "",
@@ -203,7 +206,13 @@ export default class ExecuteCodePlugin extends Plugin {
 
 				this.runCode(srcCode, out, button, this.settings.RPath, this.settings.RArgs, "R");
 			});
-		}
+		} else if (language.contains("language-go")) {
+            button.addEventListener("click" , () => {
+                // button.className = runButtonDisabledClass;
+
+				this.runCode(srcCode, out, button, this.settings.golangPath, this.settings.golangArgs, this.settings.golangFileExtension);
+            })
+        }
 	}
 
 	private getVaultVariables() {


### PR DESCRIPTION
This PR fixes #42. Adds golang support to running code.Simply start a code block with
'```go'

Things to note:
- You need to add everything needed in a Go file (including `package` and main function).
- I am not a js/ts developer thus, formatting and general code health need to be reviewed.


Thanks for creating this plugin. Really helped me maintain my notes!
