### PR TITLE
Added rust support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ executed programm now.
 		  fmt.Println("Hello World")
 	  }
   ```
+- Rust
+	- Requirements: Cargo is installed and correct path is set in the settings(`cargo` binary is available).
+    - `cargo-eval` is installed. Install using `cargo install cargo-eval`.
+    - Import statements and external crates is supported by `cargo-eval`. Read their [documentation](https://github.com/reitermarkus/cargo-eval).
+	- Every code block must a main function.
+  ```rust
+	  fn main() {
+		  println!("Hello World");
+	  }
+  ```
 
 - Squiggle: For Squiggle support look at the [Obsidian Squiggle plugin](https://github.com/jqhoogland/obsidian-squiggle)
   by @jqhoogland.

--- a/SettingsTab.ts
+++ b/SettingsTab.ts
@@ -86,6 +86,19 @@ export class SettingsTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				}));
 
+        // ========== Rust ===========
+		containerEl.createEl('h3', {text: 'Rust Settings'});
+		new Setting(containerEl)
+			.setName('Cargo Path')
+			.setDesc('The path to your Cargo installation.')
+			.addText(text => text
+				.setValue(this.plugin.settings.cargoPath)
+				.onChange(async (value) => {
+					this.plugin.settings.cargoPath = value;
+					console.log('Cargo path set to: ' + value);
+					await this.plugin.saveSettings();
+				}));
+
 		// ========== Python ==========
 		containerEl.createEl('h3', {text: 'Python Settings'});
 		new Setting(containerEl)

--- a/main.ts
+++ b/main.ts
@@ -18,7 +18,7 @@ import * as JSCPP from "JSCPP";
 // @ts-ignore
 import * as prolog from "tau-prolog";
 
-const supportedLanguages = ["js", "javascript", "python", "cpp", "prolog", "shell", "bash", "groovy", "r", "go"];
+const supportedLanguages = ["js", "javascript", "python", "cpp", "prolog", "shell", "bash", "groovy", "r", "go", "rust"];
 
 const buttonText = "Run";
 
@@ -42,6 +42,9 @@ const DEFAULT_SETTINGS: ExecutorSettings = {
     golangPath: "go",
     golangArgs: "run",
     golangFileExtension: "go",
+    cargoPath: "cargo",
+    cargoArgs: "run",
+    rustFileExtension: "rs",
 	maxPrologAnswers: 15,
 	RPath: "Rscript",
 	RArgs: "",
@@ -198,7 +201,14 @@ export default class ExecuteCodePlugin extends Plugin {
 				this.runGroovyCode(srcCode, out, button);
 			});
 
-		} else if (language.contains("language-r")) {
+		} else if (language.contains("language-rust")) {
+            button.addEventListener("click" , () => {
+                button.className = runButtonDisabledClass;
+
+				this.runCode(srcCode, out, button, this.settings.cargoPath, this.settings.cargoArgs, this.settings.rustFileExtension);
+            });
+
+        } else if (language.contains("language-r")) {
 			button.addEventListener("click", () => {
 				button.className = runButtonDisabledClass;
 
@@ -212,7 +222,7 @@ export default class ExecuteCodePlugin extends Plugin {
                 button.className = runButtonDisabledClass;
 
 				this.runCode(srcCode, out, button, this.settings.golangPath, this.settings.golangArgs, this.settings.golangFileExtension);
-            })
+            });
         }
 	}
 


### PR DESCRIPTION
This PR fixes #21 . Adds rust support using `cargo-eval`.

Points to focus
- Every rust code block must have main function.
- Dependencies and external crates are supported by `cargo-eval`.