### PR TITLE
Replace JSCPP with Cling for C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,15 @@ access paths in obsidian or show images in your notes.
   ```
 
 - CPP
-	- Requirements: NO requirements, works with [JSCPP](https://github.com/felixhao28/JSCPP).
-	- Problems: No error handling implemented yet and JSCPP doesn't support all language features.
+	- Requirements: [Cling](https://github.com/root-project/cling) is installed and correct path is set in the settings.
+	- Every code block must contain a main function.
     ```cpp
     #include <iostream>
+	#include <string>
+
     using namespace std;
 
-    void hello(char name[]) {
+    void hello(string name) {
         cout << "Hello " << name << "!\n";
     }
 

--- a/SettingsTab.ts
+++ b/SettingsTab.ts
@@ -184,9 +184,7 @@ export class SettingsTab extends PluginSettingTab {
 		containerEl.createEl('h3', {text: 'C++ Settings'});
 		new Setting(containerEl)
 			.setName('C++ Runner')
-			.setDesc('Prefer Cling for the best C++ experience.')
 			.addDropdown(dropdown => dropdown
-				.addOption('jscpp', 'JSCPP')
 				.addOption('cling', 'Cling')
 				.setValue(this.plugin.settings.cppRunner)
 				.onChange(async (value) => {

--- a/SettingsTab.ts
+++ b/SettingsTab.ts
@@ -27,10 +27,10 @@ export interface ExecutorSettings {
 	cargoPath: string;
 	cargoArgs: string;
 	cppRunner: string;
+	cppInject: string;
 	clingPath: string;
 	clingArgs: string;
 	clingStd: string;
-	clingInject: string;
 	rustFileExtension: string,
 	RPath: string;
 	RArgs: string;
@@ -197,11 +197,11 @@ export class SettingsTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName('C++ inject code')
 			.setDesc('Code to add to the top of every C++ code block. Can be #include, #define, using directives, etc.')
-			.setClass('code-input-box')
+			.setClass('settings-code-input-box')
 			.addTextArea(textarea => textarea
-				.setValue(this.plugin.settings.clingInject)
+				.setValue(this.plugin.settings.cppInject)
 				.onChange(async (value) => {
-					this.plugin.settings.clingInject = value;
+					this.plugin.settings.cppInject = value;
 					console.log('C++ inject set to: ' + value);
 					await this.plugin.saveSettings();
 				}));

--- a/SettingsTab.ts
+++ b/SettingsTab.ts
@@ -1,4 +1,4 @@
-import {App, DropdownComponent, PluginSettingTab, Setting} from "obsidian";
+import {App, PluginSettingTab, Setting} from "obsidian";
 import ExecuteCodePlugin from "./main";
 
 export interface ExecutorSettings {
@@ -183,18 +183,8 @@ export class SettingsTab extends PluginSettingTab {
 		// ========== C++ ===========
 		containerEl.createEl('h3', {text: 'C++ Settings'});
 		new Setting(containerEl)
-			.setName('C++ Runner')
-			.addDropdown(dropdown => dropdown
-				.addOption('cling', 'Cling')
-				.setValue(this.plugin.settings.cppRunner)
-				.onChange(async (value) => {
-					this.plugin.settings.cppRunner = value;
-					console.log('C++ runner set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('C++ inject code')
-			.setDesc('Code to add to the top of every C++ code block. Can be #include, #define, using directives, etc.')
+			.setName('Inject C++ code')
+			.setDesc('Code to add to the top of every C++ code block before running. Can be #include, #define, using directives, etc.')
 			.setClass('settings-code-input-box')
 			.addTextArea(textarea => textarea
 				.setValue(this.plugin.settings.cppInject)

--- a/SettingsTab.ts
+++ b/SettingsTab.ts
@@ -1,4 +1,4 @@
-import {App, PluginSettingTab, Setting} from "obsidian";
+import {App, DropdownComponent, PluginSettingTab, Setting} from "obsidian";
 import ExecuteCodePlugin from "./main";
 
 export interface ExecutorSettings {
@@ -25,7 +25,12 @@ export interface ExecutorSettings {
 	powershellArgs: string;
 	powershellFileExtension: string;
 	cargoPath: string;
-	cargoArgs: string,
+	cargoArgs: string;
+	cppRunner: string;
+	clingPath: string;
+	clingArgs: string;
+	clingStd: string;
+	clingInject: string;
 	rustFileExtension: string,
 	RPath: string;
 	RArgs: string;
@@ -171,6 +176,65 @@ export class SettingsTab extends PluginSettingTab {
 					let sanitized = this.sanitizePath(value);
 					this.plugin.settings.cargoPath = sanitized;
 					console.log('Cargo path set to: ' + sanitized);
+					await this.plugin.saveSettings();
+				}));
+
+
+		// ========== C++ ===========
+		containerEl.createEl('h3', {text: 'C++ Settings'});
+		new Setting(containerEl)
+			.setName('C++ Runner')
+			.setDesc('Prefer Cling for the best C++ experience.')
+			.addDropdown(dropdown => dropdown
+				.addOption('jscpp', 'JSCPP')
+				.addOption('cling', 'Cling')
+				.setValue(this.plugin.settings.cppRunner)
+				.onChange(async (value) => {
+					this.plugin.settings.cppRunner = value;
+					console.log('C++ runner set to: ' + value);
+					await this.plugin.saveSettings();
+				}));
+		new Setting(containerEl)
+			.setName('C++ inject code')
+			.setDesc('Code to add to the top of every C++ code block. Can be #include, #define, using directives, etc.')
+			.setClass('code-input-box')
+			.addTextArea(textarea => textarea
+				.setValue(this.plugin.settings.clingInject)
+				.onChange(async (value) => {
+					this.plugin.settings.clingInject = value;
+					console.log('C++ inject set to: ' + value);
+					await this.plugin.saveSettings();
+				}));
+		new Setting(containerEl)
+			.setName('Cling path')
+			.setDesc('The path to your Cling installation.')
+			.addText(text => text
+				.setValue(this.plugin.settings.clingPath)
+				.onChange(async (value) => {
+					const sanitized = this.sanitizePath(value);
+					this.plugin.settings.clingPath = sanitized;
+					console.log('Cling path set to: ' + sanitized);
+					await this.plugin.saveSettings();
+				}));
+		new Setting(containerEl)
+			.setName('Cling arguments')
+			.addText(text => text
+				.setValue(this.plugin.settings.clingArgs)
+				.onChange(async (value) => {
+					this.plugin.settings.clingArgs = value;
+					console.log('Cling args set to: ' + value);
+					await this.plugin.saveSettings();
+				}));
+		new Setting(containerEl)
+			.setName('Cling std')
+			.addDropdown(dropdown => dropdown
+				.addOption('c++11', 'C++ 11')
+				.addOption('c++14', 'C++ 14')
+				.addOption('c++17', 'C++ 17')
+				.setValue(this.plugin.settings.clingStd)
+				.onChange(async (value) => {
+					this.plugin.settings.clingStd = value;
+					console.log('Cling std set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
 

--- a/main.ts
+++ b/main.ts
@@ -53,10 +53,10 @@ const DEFAULT_SETTINGS: ExecutorSettings = {
 	cargoPath: "cargo",
 	cargoArgs: "run",
 	cppRunner: "jscpp",
+	cppInject: "",
 	clingPath: "cling",
 	clingArgs: "",
 	clingStd: "c++17",
-	clingInject: "",
 	rustFileExtension: "rs",
 	RPath: "Rscript",
 	RArgs: "",
@@ -205,12 +205,13 @@ export default class ExecuteCodePlugin extends Plugin {
 			button.addEventListener("click", () => {
 				button.className = runButtonDisabledClass;
 				out.clear();
+				const cppCode = `${this.settings.cppInject}\n${srcCode}`;
 				switch(this.settings.cppRunner) {
-					case "jcpp":
-						this.runJscpp(srcCode, out);
+					case "jscpp":
+						this.runJscpp(cppCode, out);
 						break;
 					case "cling":
-						this.runCode(srcCode, out, button, this.settings.clingPath, `-std=${this.settings.clingStd} ${this.settings.clingArgs}`, "cpp");
+						this.runCode(cppCode, out, button, this.settings.clingPath, `-std=${this.settings.clingStd} ${this.settings.clingArgs}`, "cpp");
 						break;
 				}
 				button.className = runButtonClass;

--- a/main.ts
+++ b/main.ts
@@ -204,11 +204,7 @@ export default class ExecuteCodePlugin extends Plugin {
 				button.className = runButtonDisabledClass;
 				out.clear();
 				const cppCode = `${this.settings.cppInject}\n${srcCode}`;
-				switch(this.settings.cppRunner) {
-					case "cling":
-						this.runCode(cppCode, out, button, this.settings.clingPath, `-std=${this.settings.clingStd} ${this.settings.clingArgs}`, "cpp");
-						break;
-				}
+				this.runCode(cppCode, out, button, this.settings.clingPath, `-std=${this.settings.clingStd} ${this.settings.clingArgs}`, "cpp");
 				button.className = runButtonClass;
 			})
 

--- a/main.ts
+++ b/main.ts
@@ -14,8 +14,6 @@ import {
 	insertVaultPath
 } from "./Magic";
 // @ts-ignore
-import * as JSCPP from "JSCPP";
-// @ts-ignore
 import * as prolog from "tau-prolog";
 
 const supportedLanguages = ["js", "javascript", "python", "cpp", "prolog", "shell", "bash", "groovy", "r", "go", "rust",
@@ -52,7 +50,7 @@ const DEFAULT_SETTINGS: ExecutorSettings = {
 	powershellFileExtension: "ps1",
 	cargoPath: "cargo",
 	cargoArgs: "run",
-	cppRunner: "jscpp",
+	cppRunner: "cling",
 	cppInject: "",
 	clingPath: "cling",
 	clingArgs: "",
@@ -207,9 +205,6 @@ export default class ExecuteCodePlugin extends Plugin {
 				out.clear();
 				const cppCode = `${this.settings.cppInject}\n${srcCode}`;
 				switch(this.settings.cppRunner) {
-					case "jscpp":
-						this.runJscpp(cppCode, out);
-						break;
 					case "cling":
 						this.runCode(cppCode, out, button, this.settings.clingPath, `-std=${this.settings.clingStd} ${this.settings.clingArgs}`, "cpp");
 						break;
@@ -350,21 +345,6 @@ export default class ExecuteCodePlugin extends Plugin {
 				this.notifyError(cmd, cmdArgs, tempFileName, err, outputter);
 				button.className = runButtonClass;
 			});
-	}
-
-	private runJscpp(cppCode: string, out: Outputter) {
-		new Notice("Running...");
-		const config = {
-			stdio: {
-				write: (s: string) => out.write(s)
-			},
-			unsigned_overflow: "warn", // can be "error"(default), "warn" or "ignore"
-			maxTimeout: this.settings.timeout,
-		};
-		const exitCode = JSCPP.run(cppCode, 0, config);
-
-		out.write("\nprogram stopped with exit code " + exitCode);
-		new Notice(exitCode === 0 ? "Done!" : "Error!");
 	}
 
 	private runPrologCode(prologCode: string[], out: Outputter) {

--- a/main.ts
+++ b/main.ts
@@ -301,12 +301,9 @@ export default class ExecuteCodePlugin extends Plugin {
 		new Notice("Running...");
 		const [tempFileName, fileId] = this.getTempFile(ext)
 		console.debug(`Execute ${cmd} ${cmdArgs} ${tempFileName}`);
-		
-		let codeContent = codeBlockContent;
 		if (ext === "cpp")
-			codeContent = codeContent.replace(/main\(\)/g, `temp_${fileId}()`);
-
-		fs.promises.writeFile(tempFileName, codeContent)
+			codeBlockContent = codeBlockContent.replace(/main\(\)/g, `temp_${fileId}()`);
+		fs.promises.writeFile(tempFileName, codeBlockContent)
 			.then(() => {
 				const args = cmdArgs ? cmdArgs.split(" ") : [];
 				args.push(tempFileName);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"g": "^2.0.1",
-				"JSCPP": "^2.0.9",
 				"moment": "^2.29.3",
 				"original-fs": "^1.1.0",
 				"tau-prolog": "^0.3.2"
@@ -1394,16 +1393,6 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/JSCPP": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/JSCPP/-/JSCPP-2.0.9.tgz",
-			"integrity": "sha512-ix62BbyR33JfuLS5JN3lrP5WrDFHJMe498TbyEN0vjRgK1pvOREs03YA0rMoj0U2h9EYLSoo9emZMW2rSlFVfQ==",
-			"dependencies": {
-				"lodash": "^4.17.20",
-				"pegjs-util": "^1.4.21",
-				"printf": "^0.6.0"
-			}
-		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1431,11 +1420,6 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
-		},
-		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -1616,25 +1600,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/pegjs": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-			"integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
-			"bin": {
-				"pegjs": "bin/pegjs"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/pegjs-util": {
-			"version": "1.4.21",
-			"resolved": "https://registry.npmjs.org/pegjs-util/-/pegjs-util-1.4.21.tgz",
-			"integrity": "sha512-0z15BXCjxwgeD+pO5QImUgOFsJ86jFt6oDqatveLggeARSS5wmrt9SxCONkUvOeSsob2faVBC9H4wpl4zudg9A==",
-			"dependencies": {
-				"pegjs": ">=0.10.0"
-			}
-		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1655,14 +1620,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/printf": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/printf/-/printf-0.6.1.tgz",
-			"integrity": "sha512-is0ctgGdPJ5951KulgfzvHGwJtZ5ck8l042vRkV6jrkpBzTmb/lueTqguWHy2JfVA+RY6gFVlaZgUS0j7S/dsw==",
-			"engines": {
-				"node": ">= 0.9.0"
 			}
 		},
 		"node_modules/punycode": {
@@ -3029,16 +2986,6 @@
 				"argparse": "^2.0.1"
 			}
 		},
-		"JSCPP": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/JSCPP/-/JSCPP-2.0.9.tgz",
-			"integrity": "sha512-ix62BbyR33JfuLS5JN3lrP5WrDFHJMe498TbyEN0vjRgK1pvOREs03YA0rMoj0U2h9EYLSoo9emZMW2rSlFVfQ==",
-			"requires": {
-				"lodash": "^4.17.20",
-				"pegjs-util": "^1.4.21",
-				"printf": "^0.6.0"
-			}
-		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3063,11 +3010,6 @@
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
 			}
-		},
-		"lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"lodash.merge": {
 			"version": "4.6.2",
@@ -3214,19 +3156,6 @@
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"dev": true
 		},
-		"pegjs": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-			"integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
-		},
-		"pegjs-util": {
-			"version": "1.4.21",
-			"resolved": "https://registry.npmjs.org/pegjs-util/-/pegjs-util-1.4.21.tgz",
-			"integrity": "sha512-0z15BXCjxwgeD+pO5QImUgOFsJ86jFt6oDqatveLggeARSS5wmrt9SxCONkUvOeSsob2faVBC9H4wpl4zudg9A==",
-			"requires": {
-				"pegjs": ">=0.10.0"
-			}
-		},
 		"picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3239,11 +3168,6 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
 			"peer": true
-		},
-		"printf": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/printf/-/printf-0.6.1.tgz",
-			"integrity": "sha512-is0ctgGdPJ5951KulgfzvHGwJtZ5ck8l042vRkV6jrkpBzTmb/lueTqguWHy2JfVA+RY6gFVlaZgUS0j7S/dsw=="
 		},
 		"punycode": {
 			"version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 	},
 	"dependencies": {
 		"g": "^2.0.1",
-		"JSCPP": "^2.0.9",
 		"moment": "^2.29.3",
 		"original-fs": "^1.1.0",
 		"tau-prolog": "^0.3.2"

--- a/styles.css
+++ b/styles.css
@@ -46,7 +46,7 @@ code.language-output hr {
 	margin: 0 0 1em;
 }
 
-.code-input-box textarea, .code-input-box input {
+.settings-code-input-box textarea, .settings-code-input-box input {
     min-width: 400px;
 	min-height: 100px;
     font-family: monospace;

--- a/styles.css
+++ b/styles.css
@@ -45,3 +45,10 @@ code.language-output span.stderr {
 code.language-output hr {
 	margin: 0 0 1em;
 }
+
+.code-input-box textarea, .code-input-box input {
+    min-width: 400px;
+	min-height: 100px;
+    font-family: monospace;
+    resize: vertical; 
+}


### PR DESCRIPTION
JSCPP is nice to have in that it doesn't require any dependencies from the user, but the tradeoff is a much larger plugin size and a very limited set of features. [Cling](https://github.com/root-project/cling) provides a much greater C++ experience, and removes the need for a bundled interpreter, taking the plugin down from around 1.4mb to only around 430kb. This PR removes JSCPP from the plugin and adds support for Cling, along with the ability to inject code at the beginning of each C++ code block.