### PR TITLE
Add the ability to reuse code blocks

### DIFF
--- a/Magic.ts
+++ b/Magic.ts
@@ -74,7 +74,6 @@ function pythonParseShowImage(source: string): string {
 
 		const image = buildMagicShowImage(imagePath.replace(/\\/g, "\\\\"), width, height, alignment);
 		source = source.replace(match[0], "print(\'" + image + "\')");
-		console.log(source);
 	}
 
 	return source;

--- a/Magic.ts
+++ b/Magic.ts
@@ -104,7 +104,7 @@ function buildMagicShowImage(imagePath: string, width: string = "0", height: str
 	}
 
 	if (width == "0" || height == "0")
-		return `<img src="${imagePath}" align="${alignment}" alt="Image found at path ${imagePath}.>`;
+		return `<img src="${imagePath}" align="${alignment}" alt="Image found at path ${imagePath}.">`;
 
 	return `<img src="${imagePath}" width="${width}" height="${height}" align="${alignment}" alt="Image found at path ${imagePath}.">`;
 }

--- a/Magic.ts
+++ b/Magic.ts
@@ -104,7 +104,7 @@ function buildMagicShowImage(imagePath: string, width: string = "0", height: str
 	}
 
 	if (width == "0" || height == "0")
-		return `<img src="${imagePath}" align="${alignment}" alt="Image found at path ${imagePath}.">`;
+		return `<img src="${imagePath}" align="${alignment}" alt="Image found at path ${imagePath}." />`;
 
-	return `<img src="${imagePath}" width="${width}" height="${height}" align="${alignment}" alt="Image found at path ${imagePath}.">`;
+	return `<img src="${imagePath}" width="${width}" height="${height}" align="${alignment}" alt="Image found at path ${imagePath}." />`;
 }

--- a/SettingsTab.ts
+++ b/SettingsTab.ts
@@ -1,11 +1,14 @@
 import {App, PluginSettingTab, Setting} from "obsidian";
 import ExecuteCodePlugin from "./main";
+import type {supportedLanguages} from "./main";
+
+export type ExecutorSettingsLanguages = Exclude<typeof supportedLanguages[number], "javascript">;
 
 export interface ExecutorSettings {
 	timeout: number;
 	nodePath: string;
 	nodeArgs: string;
-	nodeInject: string;
+	jsInject: string;
 	pythonPath: string;
 	pythonArgs: string;
 	pythonEmbedPlots: boolean;
@@ -21,7 +24,7 @@ export interface ExecutorSettings {
 	golangPath: string,
 	golangArgs: string,
 	golangFileExtension: string,
-	golangInject: string;
+	goInject: string;
 	javaPath: string,
 	javaArgs: string,
 	javaFileExtension: string,
@@ -105,7 +108,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('Node args set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
-		this.makeInjectSetting("javascript", "JavaScript");
+		this.makeInjectSetting("js", "JavaScript");
 
 
 		// ========== Java ==========
@@ -180,7 +183,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('Golang path set to: ' + sanitized);
 					await this.plugin.saveSettings();
 				}));
-		this.makeInjectSetting("golang", "Golang");
+		this.makeInjectSetting("go", "Golang");
 
 
 		// ========== Rust ===========
@@ -414,15 +417,15 @@ export class SettingsTab extends PluginSettingTab {
 		return path
 	}
 
-	private makeInjectSetting(language: string, languageAlt: string) { // TODO better type safety not just string
+	private makeInjectSetting(language: ExecutorSettingsLanguages, languageAlt: string) {
 		new Setting(this.containerEl)
 			.setName(`Inject ${languageAlt} code`)
 			.setDesc(`Code to add to the top of every ${languageAlt} code block before running.`)
 			.setClass('settings-code-input-box')
 			.addTextArea(textarea => textarea
-				.setValue(this.plugin.settings[`${language}Inject` as keyof ExecutorSettings]) // TODO better type safety
+				.setValue(this.plugin.settings[`${language}Inject` as keyof ExecutorSettings])
 				.onChange(async (value) => {
-					(this.plugin.settings[`${language}Inject` as keyof ExecutorSettings] as string) = value; // TODO better type safety
+					(this.plugin.settings[`${language}Inject` as keyof ExecutorSettings] as string) = value;
 					console.log(`${language} inject set to ${value}`);
 					await this.plugin.saveSettings();
 				}));

--- a/SettingsTab.ts
+++ b/SettingsTab.ts
@@ -5,27 +5,36 @@ export interface ExecutorSettings {
 	timeout: number;
 	nodePath: string;
 	nodeArgs: string;
+	nodeInject: string;
 	pythonPath: string;
 	pythonArgs: string;
 	pythonEmbedPlots: boolean;
+	pythonInject: string;
 	shellPath: string;
 	shellArgs: string;
 	shellFileExtension: string;
+	shellInject: string;
 	groovyPath: string;
 	groovyArgs: any;
 	groovyFileExtension: string;
+	groovyInject: string;
 	golangPath: string,
 	golangArgs: string,
 	golangFileExtension: string,
+	golangInject: string;
 	javaPath: string,
 	javaArgs: string,
 	javaFileExtension: string,
+	javaInject: string;
 	maxPrologAnswers: number;
+	prologInject: string;
 	powershellPath: string;
 	powershellArgs: string;
 	powershellFileExtension: string;
+	powershellInject: string;
 	cargoPath: string;
 	cargoArgs: string;
+	rustInject: string;
 	cppRunner: string;
 	cppInject: string;
 	clingPath: string;
@@ -35,9 +44,11 @@ export interface ExecutorSettings {
 	RPath: string;
 	RArgs: string;
 	REmbedPlots: boolean;
+	RInject: string;
 	kotlinPath: string;
 	kotlinArgs: string;
 	kotlinFileExtension: string;
+	kotlinInject: string;
 }
 
 export class SettingsTab extends PluginSettingTab {
@@ -69,7 +80,6 @@ export class SettingsTab extends PluginSettingTab {
 					}
 					await this.plugin.saveSettings();
 				}));
-		// TODO add collapsible region here with options for code injection for all languages
 
 		// TODO setting per language that requires main function if main function should be implicitly made or not, if not, non-main blocks will not have a run button
 
@@ -95,6 +105,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('Node args set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
+		this.makeInjectSetting("javascript", "JavaScript");
 
 
 		// ========== Java ==========
@@ -119,6 +130,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('Java args set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
+		this.makeInjectSetting("java", "Java");
 
 
 		// ========== Python ==========
@@ -152,6 +164,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('Python args set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
+		this.makeInjectSetting("python", "Python");
 
 
 		// ========== Golang =========
@@ -167,6 +180,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('Golang path set to: ' + sanitized);
 					await this.plugin.saveSettings();
 				}));
+		this.makeInjectSetting("golang", "Golang");
 
 
 		// ========== Rust ===========
@@ -182,21 +196,11 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('Cargo path set to: ' + sanitized);
 					await this.plugin.saveSettings();
 				}));
+		this.makeInjectSetting("rust", "Rust");
 
 
 		// ========== C++ ===========
 		containerEl.createEl('h3', {text: 'C++ Settings'});
-		new Setting(containerEl)
-			.setName('Inject C++ code')
-			.setDesc('Code to add to the top of every C++ code block before running. Can be #include, #define, using directives, etc.')
-			.setClass('settings-code-input-box')
-			.addTextArea(textarea => textarea
-				.setValue(this.plugin.settings.cppInject)
-				.onChange(async (value) => {
-					this.plugin.settings.cppInject = value;
-					console.log('C++ inject set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
 		new Setting(containerEl)
 			.setName('Cling path')
 			.setDesc('The path to your Cling installation.')
@@ -229,6 +233,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('Cling std set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
+		this.makeInjectSetting("cpp", "C++");
 
 
 		// ========== Shell ==========
@@ -263,6 +268,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('Shell file extension set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
+		this.makeInjectSetting("shell", "Shell");
 
 
 		// ========== Powershell ==========
@@ -297,6 +303,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('Powershell file extension set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
+		this.makeInjectSetting("powershell", "Powershell");
 
 
 		// ========== Prolog ==========
@@ -313,6 +320,7 @@ export class SettingsTab extends PluginSettingTab {
 					}
 					await this.plugin.saveSettings();
 				}));
+		this.makeInjectSetting("prolog", "Prolog");
 
 
 		// ========== Groovy ==========
@@ -337,6 +345,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('Groovy args set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
+		this.makeInjectSetting("groovy", "Groovy");
 
 
 		// ========== R ==========
@@ -370,6 +379,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('R args set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
+		this.makeInjectSetting("R", "R");
 
 		// ========== Kotlin ==========
 		containerEl.createEl('h3', {text: 'Kotlin Settings'});
@@ -393,6 +403,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('Kotlin args set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
+		this.makeInjectSetting("kotlin", "Kotlin");
 	}
 
 	private sanitizePath(path: string): string {
@@ -401,5 +412,19 @@ export class SettingsTab extends PluginSettingTab {
 		path = path.trim();
 
 		return path
+	}
+
+	private makeInjectSetting(language: string, languageAlt: string) {
+		new Setting(this.containerEl)
+			.setName(`Inject ${languageAlt} code`)
+			.setDesc(`Code to add to the top of every ${languageAlt} code block before running.`)
+			.setClass('settings-code-input-box')
+			.addTextArea(textarea => textarea
+				.setValue(this.plugin.settings[`${language}Inject` as keyof ExecutorSettings])
+				.onChange(async (value) => {
+					(this.plugin.settings[`${language}Inject` as keyof ExecutorSettings] as string) = value;
+					console.log(`${language} inject set to ${value}`);
+					await this.plugin.saveSettings();
+				}));
 	}
 }

--- a/SettingsTab.ts
+++ b/SettingsTab.ts
@@ -44,7 +44,7 @@ export interface ExecutorSettings {
 	RPath: string;
 	RArgs: string;
 	REmbedPlots: boolean;
-	RInject: string;
+	rInject: string;
 	kotlinPath: string;
 	kotlinArgs: string;
 	kotlinFileExtension: string;
@@ -360,8 +360,8 @@ export class SettingsTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				}));
 		new Setting(containerEl)
-			.setName('R path')
-			.setDesc('The path to your R installation.')
+			.setName('Rscript path')
+			.setDesc('The path to your Rscript installation. Ensure you provide the Rscript binary instead of the ordinary R binary.')
 			.addText(text => text
 				.setValue(this.plugin.settings.RPath)
 				.onChange(async (value) => {
@@ -379,7 +379,7 @@ export class SettingsTab extends PluginSettingTab {
 					console.log('R args set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
-		this.makeInjectSetting("R", "R");
+		this.makeInjectSetting("r", "R");
 
 		// ========== Kotlin ==========
 		containerEl.createEl('h3', {text: 'Kotlin Settings'});
@@ -414,15 +414,15 @@ export class SettingsTab extends PluginSettingTab {
 		return path
 	}
 
-	private makeInjectSetting(language: string, languageAlt: string) {
+	private makeInjectSetting(language: string, languageAlt: string) { // TODO better type safety not just string
 		new Setting(this.containerEl)
 			.setName(`Inject ${languageAlt} code`)
 			.setDesc(`Code to add to the top of every ${languageAlt} code block before running.`)
 			.setClass('settings-code-input-box')
 			.addTextArea(textarea => textarea
-				.setValue(this.plugin.settings[`${language}Inject` as keyof ExecutorSettings])
+				.setValue(this.plugin.settings[`${language}Inject` as keyof ExecutorSettings]) // TODO better type safety
 				.onChange(async (value) => {
-					(this.plugin.settings[`${language}Inject` as keyof ExecutorSettings] as string) = value;
+					(this.plugin.settings[`${language}Inject` as keyof ExecutorSettings] as string) = value; // TODO better type safety
 					console.log(`${language} inject set to ${value}`);
 					await this.plugin.saveSettings();
 				}));

--- a/SettingsTab.ts
+++ b/SettingsTab.ts
@@ -54,8 +54,9 @@ export class SettingsTab extends PluginSettingTab {
 
 		containerEl.createEl('h2', {text: 'Settings for the Code Execution Plugin.'});
 
-		// ========== Timeout ==========
-		containerEl.createEl('h3', {text: 'Timout Settings'});
+
+		// ========== General ==========
+		containerEl.createEl('h3', {text: 'General Settings'});
 		new Setting(containerEl)
 			.setName('Timeout (in seconds)')
 			.setDesc('The time after which a program gets shut down automatically. This is to prevent infinite loops. ')
@@ -68,6 +69,9 @@ export class SettingsTab extends PluginSettingTab {
 					}
 					await this.plugin.saveSettings();
 				}));
+		// TODO add collapsible region here with options for code injection for all languages
+
+		// TODO setting per language that requires main function if main function should be implicitly made or not, if not, non-main blocks will not have a run button
 
 
 		// ========== JavaScript / Node ==========

--- a/main.ts
+++ b/main.ts
@@ -15,9 +15,10 @@ import {
 } from "./Magic";
 // @ts-ignore
 import * as prolog from "tau-prolog";
+import type {ExecutorSettingsLanguages} from "./SettingsTab";
 
-const supportedLanguages = ["js", "javascript", "python", "cpp", "prolog", "shell", "bash", "groovy", "r", "go", "rust",
-	"java", "powershell", "kotlin"];
+export const supportedLanguages = ["js", "javascript", "python", "cpp", "prolog", "shell", "bash", "groovy", "r", "go", "rust",
+	"java", "powershell", "kotlin"] as const;
 const languagePrefixes = ["run", "pre", "post"];
 
 const buttonText = "Run";
@@ -30,7 +31,7 @@ const DEFAULT_SETTINGS: ExecutorSettings = {
 	timeout: 10000,
 	nodePath: "node",
 	nodeArgs: "",
-	nodeInject: "",
+	jsInject: "",
 	pythonPath: "python",
 	pythonArgs: "",
 	pythonEmbedPlots: true,
@@ -46,7 +47,7 @@ const DEFAULT_SETTINGS: ExecutorSettings = {
 	golangPath: "go",
 	golangArgs: "run",
 	golangFileExtension: "go",
-	golangInject: "",
+	goInject: "",
 	javaPath: "java",
 	javaArgs: "-ea",
 	javaFileExtension: "java",
@@ -157,7 +158,7 @@ export default class ExecuteCodePlugin extends Plugin {
 		return language.replace("javascript", "js");
 	}
 
-	private async injectCode(srcCode: string, _language: string) { // TODO enforce valid language, not just string
+	private async injectCode(srcCode: string, _language: ExecutorSettingsLanguages) {
 		let prependSrcCode = "";
 		let appendSrcCode = "";
 
@@ -218,10 +219,6 @@ export default class ExecuteCodePlugin extends Plugin {
 				const parent = pre.parentElement as HTMLDivElement;
 
 				const srcCode = codeBlock.getText();
-
-				// TODO doesn't look like clear button being added to the outputs?
-
-				// TODO If don't have main function and requires main function, pressing run put the entire code block in a main function
 
 				if (supportedLanguages.some((lang) => language.contains(`language-${lang}`))
 					&& !parent.classList.contains(hasButtonClass)) { // unsupported language

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,7 @@ button.run-code-button {
     right: 0;
     margin: 5px;
     padding: 5px 20px 5px 20px;
+	z-index: 100;
 }
 
 button.clear-button {
@@ -16,6 +17,7 @@ button.clear-button {
     left: 0;
     margin: 5px;
     padding: 5px 20px 5px 20px;
+	z-index: 100;
 }
 
 pre:hover .run-code-button {


### PR DESCRIPTION
This PR adds the ability to define pre / post code blocks by adding `pre-` or `post-` as a prefix to the code block language respectively. Pre blocks will be added to the top of any code block being run, and post blocks will be added to the bottom. They will only apply to code blocks defined below them, and will only apply to code blocks from the same language (however aliasing is supported, right now `javascript` and `js` can be used interchangeably across code blocks).

As an added feature, all languages have a 'global inject' option that allows defining code to be added to the top of every single code block on a per-language basis. Code reuse fully works with all languages, and all existing magic commands, including showing images, and inline plot outputs.

Obsidian when rendering markdown only renders what's in view, which means we can't go through and traverse the DOM. Instead, this PR loads the current document file and traverses line-by-line from  the top down to get all code blocks. When traversing top down, we need to detect when we've reached the code block the user is running so we stop there, since we only include pre and post blocks defined above. However, since we aren't traversing the DOM, rather text, we can't compare for node equality, and instead rely on string comparisons.

The implementation in this PR is quite fast, taking only a couple ms in my testing on very large documents with an unreasonably large number of code blocks. However, there is one edge case that the implementation will mishandle: suppose we are running a code block `main-block-2`, but we have another block with *exactly* the same contents `main-block-1` defined above. Since we're traversing from top to bottom and checking for string equality, as soon as we reach `main-block-1`, even though it's not the one the user is running, since the string contents is exactly the same, the traversal will stop there. So in a situation that looks like

```
pre-block-1
main-block-1
pre-block-2
main-block-2
```
When executing `main-block-2` then, only `pre-block-1` will be injected, where the intention was to also include `pre-block-2`. In my opinion, this is such a rare case that it shouldn't matter for now, but it may be interesting to explore ways to fix this in future without a significant performance impact