### PR TITLE
Add code block args documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ The following magic commands are supported:
 Adding `run-` before the language name in the code blocks (as in the example below) renders the code block in the preview already.
 This allows you to execute the code in the preview.
 
-```
+``````
 ```run-python
 def hello(name):
 print("Hello", name)
@@ -254,9 +254,19 @@ print("Hello", name)
         hello("Eve")
 `````` 
 
+## Code Block Arguments
+
+Code blocks support specifying additional arguments in the form `{key='value', otherkey=['val1', 'val2']}`. Add them to code blocks like so:
+
+`````
+```python {label='my label'}
+print('my labelled code block')
+```
+`````
+
 ## Global Code Injection and Reusing Code Blocks
 
-Sometimes it is helpful to have code that is executed before or after each other block of the same language. This plugin supports this in two ways:
+Sometimes it is helpful to have code that is executed before or after each other block of the same language. This plugin supports this in a few ways:
 
 ### Global Injection in the Settings
 
@@ -264,18 +274,67 @@ All languages have a 'global inject' option in the settings that allows defining
 
 ### Note-wide Pre- and Post-Code Blocks
 
-You can add `Pre` before the language name to create a block that is executed before each following code block:
+You can specify the `pre` argument to create a block that is executed before each following code block:
 
-```
-```pre-python
+``````
+```python {pre}
 import pandas as pd
+```
 ``````
 
 This code block is added before each python block you define below in the note and import the pandas package.
 
-`Post` blocks work the same way but the code in post blocks is executed _after_ your other code blocks.
+`post` blocks work the same way, but the code in post blocks is executed _after_ your other code blocks.
 
-Pre-/Post-blocks will only apply to code blocks defined below them, and will only apply to code blocks from the same language.
+Pre/Post blocks will only apply to code blocks defined below them, and will only apply to code blocks from the same language.
+
+You can also have a pre and post block at the same time by specifying `{pre, post}`
+
+Note, the `pre`/`post` arguments are special in that you don't need to explicitly state a key/value pair, however you can do so if you wish:
+
+`{pre}` is equivalent to `{export='pre'}`, `{pre, post}` is equivalent to `{export=['pre', 'post']}`.
+
+### Labelled Code Blocks
+
+You can label specific code blocks with the `label='string'` argument, then import them explicitly in other blocks with the `import='string'` or `import=['string1', 'string2', ...]` argument so they aren't automatically imported as with pre / post blocks:
+
+`````
+```python {label='block 1'}
+print('running block 1')
+```
+
+```python {label='block 2'}
+print('running block 2')
+```
+
+```python {import=['block 1', 'block 2']}
+print('should run block 1 and 2')
+```
+`````
+
+Labelled code blocks will be executed before the code block being run, however after global injects and pre blocks.
+
+### Ignoring Code Exports
+
+In case you want to manually ignore specific exports in a code block like pre / post / global exports, you can do so with the `ignore` argument that accepts either `pre`, `post`, `global`, an array of any of these 3, or `all` to ignore all exports:
+
+`````
+```python {pre}
+print('running pre block')
+```
+
+```python {post}
+print('running post block')
+```
+
+```python {ignore='all'}
+print('should not run any global injects or pre / post blocks')
+```
+
+```python {ignore=['global', 'pre']}
+print('should not run any pre blocks or global injects')
+```
+`````
 
 ## Installation
 


### PR DESCRIPTION
Adds documentation about code block args to the readme and updates previous pre / post block information.

As a side note, the readme is getting pretty cluttered, maybe we should have collapsible regions for language information like in https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab.