### PR TITLE
Make clear button unobtrusive on mouseover over code output

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -32,6 +32,10 @@ pre:hover .run-button-disabled, pre:hover .clear-button-disabled {
 	display: none;
 }
 
+pre:hover code.language-output {
+    margin-bottom: 23px;
+}
+
 code.language-output span.stdout {
 	color: var(--text-muted);
 }


### PR DESCRIPTION
Just a simple style tweak to make clear buttons less obtrusive when hovering over the code output:

![image](https://user-images.githubusercontent.com/56327606/193821914-12da183c-95b5-479a-be7d-af42b32a8fcb.png)

Appearance is unchanged when not hovering:

![image](https://user-images.githubusercontent.com/56327606/193822015-8ee5ed3c-7ac5-458f-b51b-2089d8b5cb81.png)
