### PR TITLE
[BUG FIX] Proper handling of languages which are substrings

### DIFF
--- a/src/TransformCode.ts
+++ b/src/TransformCode.ts
@@ -3,7 +3,7 @@ import {insertNotePath, insertNoteTitle, insertVaultPath} from "./Magic";
 import {getVaultVariables} from "./Vault";
 import * as JSON5 from "json5";
 import type {ExecutorSettings} from "./Settings";
-import { LanguageId } from "./main";
+import { cannonicalLanguages, LanguageId } from "./main";
 
 type ExportType = "pre" | "post";
 
@@ -25,8 +25,10 @@ interface CodeBlockArgs {
  * @param language A language name or shortcut (e.g. 'js', 'python' or 'shell').
  * @returns The same language shortcut for every alias of the language.
  */
-export function getLanguageAlias(language: string) : LanguageId {
-	return language
+export function getLanguageAlias(language: string | undefined) : LanguageId | undefined {
+	if(typeof language !== "string") return undefined;
+	
+	const replaced = language
 		.replace("javascript", "js")
 		.replace("typescript", "ts")
 		.replace("csharp", "cs")
@@ -34,6 +36,9 @@ export function getLanguageAlias(language: string) : LanguageId {
 		.replace("wolfram", "mathematica")
 		.replace("nb", "mathematica")
 		.replace("wl", "mathematica") as LanguageId;
+		
+	if(cannonicalLanguages.includes(replaced)) return replaced;
+	else return undefined;
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -163,7 +163,7 @@ export default class ExecuteCodePlugin extends Plugin {
 				const srcCode = codeBlock.getText();
 
 				const cannonicalLanguage = getLanguageAlias(
-					supportedLanguages.find((lang => language.match(new RegExp(`\\blanguage-${lang}\\b`))))
+					supportedLanguages.find(lang => element.classList.contains(`language-${lang}`))
 				) as LanguageId;
 
 				if (cannonicalLanguage // if the language is supported

--- a/src/main.ts
+++ b/src/main.ts
@@ -163,7 +163,7 @@ export default class ExecuteCodePlugin extends Plugin {
 				const srcCode = codeBlock.getText();
 
 				const cannonicalLanguage = getLanguageAlias(
-					supportedLanguages.find((lang => language.contains(`language-${lang}`)))
+					supportedLanguages.find((lang => language.match(new RegExp(`\\blanguage-${lang}\\b`))))
 				) as LanguageId;
 
 				if (cannonicalLanguage // if the language is supported

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,9 +19,9 @@ import ExecutorManagerView, { EXECUTOR_MANAGER_OPEN_VIEW_COMMAND_ID, EXECUTOR_MA
 import runAllCodeBlocks from './runAllCodeBlocks';
 
 const languageAliases = ["javascript", "typescript", "bash", "csharp", "wolfram", "nb", "wl"] as const;
-const cannonicalLanguages = ["js", "ts", "cs", "lua", "python", "cpp",
+export const cannonicalLanguages = ["js", "ts", "cs", "lua", "python", "cpp",
 	"prolog", "shell", "groovy", "r", "go", "rust", "java", "powershell", "kotlin", "mathematica"] as const;
-const supportedLanguages = [...languageAliases, ...cannonicalLanguages] as const;
+export const supportedLanguages = [...languageAliases, ...cannonicalLanguages] as const;
 
 
 type SupportedLanguage = typeof supportedLanguages[number];


### PR DESCRIPTION
When languages are substrings of one another (the only current example is `r` and `rust`), the plugin will only recognize the first one, because codeblocks whose classnames contain *`language-r`*`ust` will *also* contain `language-r`. 

This PR hardens against that case by using `classList.contains(...)` instead of `classList`. I also considered using a RegExp, but ultimately decided against it because the approach (`\b`) can't be used for languages which contain more than one word-- that's not a current issue, but it's good to be future-proof