### PR TITLE
Better Behaviour for Non-Input Code

### DIFF
--- a/src/Outputter.ts
+++ b/src/Outputter.ts
@@ -8,15 +8,15 @@ export class Outputter extends EventEmitter {
 	lastPrintElem: HTMLSpanElement;
 	lastPrinted: string;
 	
-	doInput: boolean
 	inputElement: HTMLInputElement;
 	
 	hadPreviouslyPrinted: boolean;
+	inputState: "NOT_DOING" | "OPEN" | "CLOSED" | "INACTIVE";
 
 	constructor (codeBlock: HTMLElement, doInput: boolean) {
 		super();
 		
-		this.doInput = doInput;
+		this.inputState = doInput ? "INACTIVE" : "NOT_DOING";
 		this.codeBlockElement = codeBlock;
 		this.hadPreviouslyPrinted = false;
 	}
@@ -39,6 +39,7 @@ export class Outputter extends EventEmitter {
 			this.clearButton.className = "clear-button-disabled";
 			
 		this.closeInput();
+		this.inputState = "INACTIVE";
 	}
 
 	/**
@@ -83,6 +84,7 @@ export class Outputter extends EventEmitter {
 	 * Hide the input element. Stop accepting input from the user.
 	 */
 	closeInput() {		
+		this.inputState = "CLOSED";
 		if(this.inputElement)
 			this.inputElement.style.display = "none";
 	}
@@ -111,7 +113,7 @@ export class Outputter extends EventEmitter {
 		this.outputElement.classList.add("language-output");
 
 		this.outputElement.appendChild(hr);
-		if (this.doInput) this.addInputElement();
+		if (this.inputState != "NOT_DOING") this.addInputElement();
 		parentEl.appendChild(this.outputElement);
 	}
 	
@@ -211,8 +213,12 @@ export class Outputter extends EventEmitter {
 		if (!this.clearButton) this.addClearButton();
 		if (!this.outputElement) this.addOutputElement();
 		
+		this.inputState = "OPEN";
 		this.outputElement.style.display = "block";
-		if (this.inputElement) this.inputElement.style.display = "inline";
 		this.clearButton.className = "clear-button";
+		
+		setTimeout(() => {
+			if (this.inputState == "OPEN") this.inputElement.style.display = "inline";
+		}, 500)
 	}
 }

--- a/src/Outputter.ts
+++ b/src/Outputter.ts
@@ -16,8 +16,6 @@ export class Outputter extends EventEmitter {
 	constructor (codeBlock: HTMLElement, doInput: boolean) {
 		super();
 		
-		// console.log("i do input: ", doInput);
-		
 		this.doInput = doInput;
 		this.codeBlockElement = codeBlock;
 		this.hadPreviouslyPrinted = false;

--- a/src/executors/PrologExecutor.ts
+++ b/src/executors/PrologExecutor.ts
@@ -1,0 +1,97 @@
+// @ts-ignore
+import * as prolog from "tau-prolog";
+import { Outputter } from "src/Outputter";
+import Executor from "./Executor";
+import { Notice } from "obsidian";
+import { ExecutorSettings } from "src/Settings";
+
+export default class PrologExecutor extends Executor {
+    
+    runQueries: boolean;
+    maxPrologAnswers: number;
+    
+    constructor(settings: ExecutorSettings, file: string) {
+        super(file, "prolog");
+        this.runQueries = true;
+        this.maxPrologAnswers = settings.maxPrologAnswers;
+    }
+    
+    async run(code: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string): Promise<void> {
+        let prologCode = code.split(/\n+%+\s*query\n+/);
+        
+        if (prologCode.length < 2) return;	// no query found
+        
+        //Prolog does not support input
+        outputter.closeInput();
+            
+        return this.runPrologCode(prologCode[0], prologCode[1], outputter);
+    }
+    async stop() {
+        this.runQueries = false;
+        this.emit("close");
+    }
+    
+    /**
+ * Executes a string with prolog code using the TauProlog interpreter.
+ * All queries must be below a line containing only '% queries'.
+ *
+ * @param facts Contains the facts.
+ * @param queries Contains the queries.
+ * @param out The {@link Outputter} that should be used to display the output of the code.
+ */
+    private runPrologCode(facts: string, queries: string, out: Outputter) {
+        new Notice("Running...");
+        console.log(prolog);
+        const session = prolog.create();
+        console.log("created");
+        session.consult(facts
+            , {
+                success: () => {
+                    session.query(queries
+                        , {
+                            success: async (goal: any) => {
+                                console.debug(`Prolog goal: ${goal}`)
+                                let answersLeft = true;
+                                let counter = 0;
+
+                                while (answersLeft && counter < this.maxPrologAnswers) {
+                                    await session.answer({
+                                        success: function (answer: any) {
+                                            new Notice("Done!");
+                                            console.debug(`Prolog result: ${session.format_answer(answer)}`);
+                                            out.write(session.format_answer(answer) + "\n");
+                                        },
+                                        fail: function () {
+                                            /* No more answers */
+                                            answersLeft = false;
+                                        },
+                                        error: function (err: any) {
+                                            new Notice("Error!");
+                                            console.error(err);
+                                            answersLeft = false;
+                                            out.writeErr(`Error while executing code: ${err}`);
+                                        },
+                                        limit: function () {
+                                            answersLeft = false;
+                                        }
+                                    });
+                                    counter++;
+                                }
+                            },
+                            error: (err: any) => {
+                                new Notice("Error!");
+                                out.writeErr("Query failed.\n")
+                                out.writeErr(err.toString());
+                            }
+                        }
+                    )
+                },
+                error: (err: any) => {
+                    out.writeErr("Adding facts failed.\n")
+                    out.writeErr(err.toString());
+                }
+            }
+        );
+    }
+    
+}

--- a/src/executors/PrologExecutor.ts
+++ b/src/executors/PrologExecutor.ts
@@ -58,6 +58,7 @@ export default class PrologExecutor extends Executor {
                                             new Notice("Done!");
                                             console.debug(`Prolog result: ${session.format_answer(answer)}`);
                                             out.write(session.format_answer(answer) + "\n");
+                                            out.closeInput();
                                         },
                                         fail: function () {
                                             /* No more answers */
@@ -68,6 +69,7 @@ export default class PrologExecutor extends Executor {
                                             console.error(err);
                                             answersLeft = false;
                                             out.writeErr(`Error while executing code: ${err}`);
+                                            out.closeInput();
                                         },
                                         limit: function () {
                                             answersLeft = false;

--- a/src/executors/PrologExecutor.ts
+++ b/src/executors/PrologExecutor.ts
@@ -41,9 +41,7 @@ export default class PrologExecutor extends Executor {
  */
     private runPrologCode(facts: string, queries: string, out: Outputter) {
         new Notice("Running...");
-        console.log(prolog);
         const session = prolog.create();
-        console.log("created");
         session.consult(facts
             , {
                 success: () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -381,7 +381,7 @@ export default class ExecuteCodePlugin extends Plugin {
 	 */
 	private runCode(codeBlockContent: string, outputter: Outputter, button: HTMLButtonElement, cmd: string, cmdArgs: string, ext: string, language: LanguageId, file: string) {
 		const executor = this.settings[`${language}Interactive`]
-			? this.executors.getExecutorFor(file, language)
+			? this.executors.getExecutorFor(file, language, false)
 			: new NonInteractiveCodeExecutor(false, file, language);
 
 		executor.run(codeBlockContent, outputter, cmd, cmdArgs, ext).then(()=> {
@@ -405,7 +405,7 @@ export default class ExecuteCodePlugin extends Plugin {
 	 */
 	private runCodeInShell(codeBlockContent: string, outputter: Outputter, button: HTMLButtonElement, cmd: string, cmdArgs: string, ext: string, language: LanguageId, file: string) {
 		const executor = this.settings[`${language}Interactive`]
-			? this.executors.getExecutorFor(file, language)
+			? this.executors.getExecutorFor(file, language, true)
 			: new NonInteractiveCodeExecutor(true, file, language);
 
 		executor.run(codeBlockContent, outputter, cmd, cmdArgs, ext).then(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -242,7 +242,7 @@ export default class ExecuteCodePlugin extends Plugin {
 				button.className = runButtonDisabledClass;
 				out.clear();
 				const transformedCode = (await new CodeInjector(this.app, this.settings, language).injectCode(srcCode));
-				console.log("ACCESS LN 245!");
+				
 				this.runCode(transformedCode, out, button, "", "", "", language, file);
 
 				button.className = runButtonClass;


### PR DESCRIPTION
Make the input input element wait `500ms` before showing itself. This fixes #96 

Moved Prolog into its own executor. 
- This allows complete removal of the input box from Prolog code, since Prolog will never have input.
- cleans up `main.ts`

Fixes a bug where input stuck around for too long by using a state-machine-esque implementation in the Outputter to represent the input's state

I'm not sure if this is too much to do in one PR. If so, please lmk & i'll refactor the 500ms wait and the Prolog refactoring into seperate branches. 