### PR TITLE
Decouple executors from interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ hello <- function(name){
 
 hello("Bob")
 ```
-	- Plots can be embedded in the note by default. You can turn this off in the settings.
+- Plots can be embedded in the note by default. You can turn this off in the settings.
 
 ```r
 y = c(12, 15, 28, 17, 18)
@@ -124,7 +124,7 @@ public class HelloWorld {
 <details>
 <summary>Lua</summary>
 
-- Requirements: install lua and config lua path
+- Requirements: install lua and config lua path.
 
 ```lua
 print('Hello, World!')
@@ -135,7 +135,7 @@ print('Hello, World!')
 <summary>C++</summary>
 
 - Requirements: [Cling](https://github.com/root-project/cling) is installed and correct path is set in the settings.
-- Every code block must contain a main function.
+- Code will be executed line-by-line without needing a main function.
 
 ```cpp
 #include <iostream>
@@ -147,9 +147,16 @@ void hello(string name) {
 	cout << "Hello " << name << "!\n";
 }
 
-int main() {
-	hello("Alice");
-	return 0;
+hello("Alice);
+```
+
+- Main functions can be used as an entrypoint by toggling the option in settings.
+
+```cpp
+#include <iostream>
+
+void main() {
+	std::cout << "Hello, World!" << std::endl;
 }
 ```
 </details>

--- a/src/ExecutorContainer.ts
+++ b/src/ExecutorContainer.ts
@@ -80,10 +80,13 @@ export default class ExecutorContainer extends EventEmitter implements Iterable<
 	 */
 	private createExecutorFor(file: string, language: LanguageId, needsShell: boolean) {
 		// Interactive language executor
-		if (this.plugin.settings[`${language}Interactive`])
+		if (this.plugin.settings[`${language}Interactive`]) {
+			if (!(language in interactiveExecutors))
+				throw new Error(`Attempted to use interactive executor for '${language}' but no such executor exists`);
 			return new interactiveExecutors[language](this.plugin.settings, file);
+		}
 		// Custom non-interactive language executor
-		else if (Object.keys(nonInteractiveExecutors).contains(language))
+		else if (language in nonInteractiveExecutors)
 			return new nonInteractiveExecutors[language](this.plugin.settings, file);
 		// Generic non-interactive language executor
 		return new NonInteractiveCodeExecutor(needsShell, file, language);

--- a/src/ExecutorContainer.ts
+++ b/src/ExecutorContainer.ts
@@ -4,7 +4,18 @@ import NodeJSExecutor from "./executors/NodeJSExecutor";
 import NonInteractiveCodeExecutor from "./executors/NonInteractiveCodeExecutor";
 import PrologExecutor from "./executors/PrologExecutor";
 import PythonExecutor from "./executors/python/PythonExecutor";
+import CppExecutor from './executors/CppExecutor';
 import ExecuteCodePlugin, {LanguageId} from "./main";
+
+const interactiveExecutors: Partial<Record<LanguageId, any>> = {
+	"js": NodeJSExecutor,
+	"python": PythonExecutor
+};
+
+const nonInteractiveExecutors: Partial<Record<LanguageId, any>> = {
+	"prolog": PrologExecutor,
+	"cpp": CppExecutor
+};
 
 export default class ExecutorContainer extends EventEmitter implements Iterable<Executor> {
 	executors: { [key in LanguageId]?: { [key: string]: Executor } } = {}
@@ -68,27 +79,13 @@ export default class ExecutorContainer extends EventEmitter implements Iterable<
 	 * @returns a new executor associated with the given language and file
 	 */
 	private createExecutorFor(file: string, language: LanguageId, needsShell: boolean) {
-		if (this.plugin.settings[`${language}Interactive`] || this.isAlwaysInteractive(language)) {
-			switch (language) {
-				case "js":
-					return new NodeJSExecutor(this.plugin.settings, file);
-				case "python":
-					return new PythonExecutor(this.plugin.settings, file);
-				case "prolog":
-					return new PrologExecutor(this.plugin.settings, file);
-			}
-		}
+		// Interactive language executor
+		if (this.plugin.settings[`${language}Interactive`])
+			return new interactiveExecutors[language](this.plugin.settings, file);
+		// Custom non-interactive language executor
+		else if (Object.keys(nonInteractiveExecutors).contains(language))
+			return new nonInteractiveExecutors[language](this.plugin.settings, file);
+		// Generic non-interactive language executor
 		return new NonInteractiveCodeExecutor(needsShell, file, language);
-	}
-
-	/**
-	 * Checks if a language is ALWAYS interactive. __This will override a user's choice__
-	 * @param language the language to check
-	 * @returns whether the language should unconditionally be interactive
-	 */
-	private isAlwaysInteractive(language: LanguageId) {
-		return [
-			"prolog"
-		].contains(language);
 	}
 }

--- a/src/executors/CppExecutor.ts
+++ b/src/executors/CppExecutor.ts
@@ -1,28 +1,34 @@
-import {ExecutorSettings} from "src/settings/Settings";
 import NonInteractiveCodeExecutor from './NonInteractiveCodeExecutor';
+import * as child_process from "child_process";
 import type {ChildProcessWithoutNullStreams} from "child_process";
 import type {Outputter} from "src/Outputter";
+import type {ExecutorSettings} from "src/settings/Settings";
 
 export default class CppExecutor extends NonInteractiveCodeExecutor {
-	clingStd: string;
-	clingArgs: string;
-	clingPath: string;
+	settings: ExecutorSettings
 
 	constructor(settings: ExecutorSettings, file: string) {
 		super(false, file, "cpp");
-		this.clingStd = settings.clingStd;
-		this.clingArgs = settings.clingArgs;
-		this.clingPath = settings.clingPath;
+		this.settings = settings;
 	}
 
 	override async run(codeBlockContent: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string) {
 		const extension = "cpp";
-		const args = `-std=${this.clingStd} ${this.clingArgs}`;
+		const args = `-std=${this.settings.clingStd} ${this.settings.clingArgs}`;
 		// Generate a new temp file id and don't set to undefined to super.run() uses the same file id
 		this.getTempFile(extension);
 		// Cling expects the main function to have the same name as the file
 		const code = codeBlockContent.replace(/main\(\)/g, `temp_${this.tempFileId}()`);
-		super.run(code, outputter, this.clingPath, args, extension);
+
+		// Run code with a main block
+		if (this.settings.cppUseMain) {
+			super.run(code, outputter, this.settings.clingPath, args, extension);
+			return;
+		}
+		// Run code without a main block
+		const childArgs = [...args.split(" "), ...code.split("\n")];
+		const child = child_process.spawn(this.settings.clingPath, childArgs, {env: process.env, shell: this.usesShell});
+		await this.handleChildOutput(child, outputter, undefined);
 	}
 
 	override async handleChildOutput(child: ChildProcessWithoutNullStreams, outputter: Outputter, fileName: string) {		

--- a/src/executors/CppExecutor.ts
+++ b/src/executors/CppExecutor.ts
@@ -1,0 +1,45 @@
+import {ExecutorSettings} from "src/settings/Settings";
+import NonInteractiveCodeExecutor from './NonInteractiveCodeExecutor';
+import type {ChildProcessWithoutNullStreams} from "child_process";
+import type {Outputter} from "src/Outputter";
+
+export default class CppExecutor extends NonInteractiveCodeExecutor {
+	clingStd: string;
+	clingArgs: string;
+	clingPath: string;
+
+	constructor(settings: ExecutorSettings, file: string) {
+		super(false, file, "cpp");
+		this.clingStd = settings.clingStd;
+		this.clingArgs = settings.clingArgs;
+		this.clingPath = settings.clingPath;
+	}
+
+	override async run(codeBlockContent: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string) {
+		const extension = "cpp";
+		const args = `-std=${this.clingStd} ${this.clingArgs}`;
+		// Generate a new temp file id and don't set to undefined to super.run() uses the same file id
+		this.getTempFile(extension);
+		// Cling expects the main function to have the same name as the file
+		const code = codeBlockContent.replace(/main\(\)/g, `temp_${this.tempFileId}()`);
+		console.log(code);
+
+		super.run(code, outputter, this.clingPath, args, extension);
+	}
+
+	override async handleChildOutput(child: ChildProcessWithoutNullStreams, outputter: Outputter, fileName: string) {		
+		super.handleChildOutput(child, outputter, fileName);
+		child.stdout.removeListener("data", this.stdoutCb);
+		child.stderr.removeListener("data", this.stderrCb);
+		const fileId = this.tempFileId;
+		const replaceTmpId = (data: string) => {
+			return data.replace(new RegExp(`temp_${fileId}\\(\\)`, "g"), "main()");
+		}
+		child.stdout.on("data", (data) => {
+			this.stdoutCb(replaceTmpId(data.toString()));
+		});
+		child.stderr.on("data", (data) => {
+			this.stderrCb(replaceTmpId(data.toString()));
+		});
+	}
+}

--- a/src/executors/CppExecutor.ts
+++ b/src/executors/CppExecutor.ts
@@ -22,8 +22,6 @@ export default class CppExecutor extends NonInteractiveCodeExecutor {
 		this.getTempFile(extension);
 		// Cling expects the main function to have the same name as the file
 		const code = codeBlockContent.replace(/main\(\)/g, `temp_${this.tempFileId}()`);
-		console.log(code);
-
 		super.run(code, outputter, this.clingPath, args, extension);
 	}
 

--- a/src/executors/CppExecutor.ts
+++ b/src/executors/CppExecutor.ts
@@ -31,14 +31,22 @@ export default class CppExecutor extends NonInteractiveCodeExecutor {
 		await this.handleChildOutput(child, outputter, undefined);
 	}
 
+	/**
+	 * Run parent NonInteractiveCodeExecutor handleChildOutput logic, but replace temporary main function name
+	 * In all outputs from stdout and stderr callbacks, from temp_<id>() to main() to produce understandable output
+	 */
 	override async handleChildOutput(child: ChildProcessWithoutNullStreams, outputter: Outputter, fileName: string) {		
 		super.handleChildOutput(child, outputter, fileName);
+		// Remove existing stdout and stderr callbacks
 		child.stdout.removeListener("data", this.stdoutCb);
 		child.stderr.removeListener("data", this.stderrCb);
 		const fileId = this.tempFileId;
+		// Replace temp_<id>() with main()
 		const replaceTmpId = (data: string) => {
 			return data.replace(new RegExp(`temp_${fileId}\\(\\)`, "g"), "main()");
 		}
+		// Set new stdout and stderr callbacks, the same as in the parent,
+		// But replacing temp_<id>() with main()
 		child.stdout.on("data", (data) => {
 			this.stdoutCb(replaceTmpId(data.toString()));
 		});

--- a/src/executors/Executor.ts
+++ b/src/executors/Executor.ts
@@ -7,6 +7,7 @@ import {EventEmitter} from "stream";
 export default abstract class Executor extends EventEmitter {
 	language: LanguageId;
 	file: string;
+	tempFileId: string | undefined = undefined;
 
 	constructor(file: string, language: LanguageId) {
 		super();
@@ -51,12 +52,15 @@ export default abstract class Executor extends EventEmitter {
 	/**
 	 * Creates a new unique file name for the given file extension. The file path is set to the temp path of the os.
 	 * The file name is the current timestamp: '/{temp_dir}/temp_{timestamp}.{file_extension}'
+	 * this.tempFileId will be updated, accessible to other methods
+	 * Once finished using this value, remember to set it to undefined to generate a new file
 	 *
 	 * @param ext The file extension. Should correspond to the language of the code.
-	 * @returns [string, number] The file path and the file name without extension.
+	 * @returns The temporary file path
 	 */
-	protected getTempFile(ext: string): [string, number] {
-		const now = Date.now();
-		return [`${os.tmpdir()}/temp_${now}.${ext}`, now];
+	protected getTempFile(ext: string) {
+		if (this.tempFileId === undefined)
+			this.tempFileId = Date.now().toString();
+		return `${os.tmpdir()}/temp_${this.tempFileId}.${ext}`;
 	}
 }

--- a/src/executors/NonInteractiveCodeExecutor.ts
+++ b/src/executors/NonInteractiveCodeExecutor.ts
@@ -23,7 +23,6 @@ export default class NonInteractiveCodeExecutor extends Executor {
 	async run(codeBlockContent: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string) {
 		new Notice("Running...");
 		const tempFileName = this.getTempFile(ext);
-		this.tempFileId = undefined; // Reset the file id to use a new file next time
 		console.debug(`Execute ${cmd} ${cmdArgs} ${tempFileName}`);
 
 		try {
@@ -39,6 +38,8 @@ export default class NonInteractiveCodeExecutor extends Executor {
 		} catch (err) {
 			this.notifyError(cmd, cmdArgs, tempFileName, err, outputter);
 		}
+		
+		this.tempFileId = undefined; // Reset the file id to use a new file next time
 	}
 
 	/**

--- a/src/executors/NonInteractiveCodeExecutor.ts
+++ b/src/executors/NonInteractiveCodeExecutor.ts
@@ -7,6 +7,8 @@ import {LanguageId} from "src/main";
 
 export default class NonInteractiveCodeExecutor extends Executor {
 	usesShell: boolean
+	stdoutCb: (chunk: any) => void
+	stderrCb: (chunk: any) => void
 
 	constructor(usesShell: boolean, file: string, language: LanguageId) {
 		super(file, language);
@@ -20,20 +22,19 @@ export default class NonInteractiveCodeExecutor extends Executor {
 
 	async run(codeBlockContent: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string) {
 		new Notice("Running...");
-		const [tempFileName, fileId] = this.getTempFile(ext)
+		const tempFileName = this.getTempFile(ext);
+		this.tempFileId = undefined; // Reset the file id to use a new file next time
 		console.debug(`Execute ${cmd} ${cmdArgs} ${tempFileName}`);
-		if (ext === "cpp")
-			codeBlockContent = codeBlockContent.replace(/main\(\)/g, `temp_${fileId}()`);
 
 		try {
 			await fs.promises.writeFile(tempFileName, codeBlockContent);
-
+			
 			const args = cmdArgs ? cmdArgs.split(" ") : [];
 			args.push(tempFileName);
-
+			
 			console.debug(`Execute ${cmd} ${args.join(" ")}`);
 			const child = child_process.spawn(cmd, args, {env: process.env, shell: this.usesShell});
-
+			
 			await this.handleChildOutput(child, outputter, tempFileName);
 		} catch (err) {
 			this.notifyError(cmd, cmdArgs, tempFileName, err, outputter);
@@ -49,15 +50,18 @@ export default class NonInteractiveCodeExecutor extends Executor {
 	 * @param fileName The name of the temporary file that was created for the code execution.
 	 * @returns a promise that will resolve when the child proces finishes
 	 */
-	private async handleChildOutput(child: child_process.ChildProcessWithoutNullStreams, outputter: Outputter, fileName: string) {
+	protected async handleChildOutput(child: child_process.ChildProcessWithoutNullStreams, outputter: Outputter, fileName: string) {
 		outputter.clear();
 
-		child.stdout.on('data', (data) => {
+		this.stdoutCb = (data) => {
 			outputter.write(data.toString());
-		});
-		child.stderr.on('data', (data) => {
+		};
+		this.stderrCb = (data) => {
 			outputter.writeErr(data.toString());
-		});
+		};
+
+		child.stdout.on('data', this.stdoutCb);
+		child.stderr.on('data', this.stderrCb);
 
 		outputter.on("data", (data: string) => {
 			child.stdin.write(data);

--- a/src/executors/NonInteractiveCodeExecutor.ts
+++ b/src/executors/NonInteractiveCodeExecutor.ts
@@ -38,7 +38,7 @@ export default class NonInteractiveCodeExecutor extends Executor {
 		} catch (err) {
 			this.notifyError(cmd, cmdArgs, tempFileName, err, outputter);
 		}
-		
+
 		this.tempFileId = undefined; // Reset the file id to use a new file next time
 	}
 
@@ -51,7 +51,7 @@ export default class NonInteractiveCodeExecutor extends Executor {
 	 * @param fileName The name of the temporary file that was created for the code execution.
 	 * @returns a promise that will resolve when the child proces finishes
 	 */
-	protected async handleChildOutput(child: child_process.ChildProcessWithoutNullStreams, outputter: Outputter, fileName: string) {
+	protected async handleChildOutput(child: child_process.ChildProcessWithoutNullStreams, outputter: Outputter, fileName: string | undefined) {
 		outputter.clear();
 
 		this.stdoutCb = (data) => {
@@ -72,6 +72,8 @@ export default class NonInteractiveCodeExecutor extends Executor {
 			new Notice(code === 0 ? "Done!" : "Error!");
 
 			outputter.closeInput();
+
+			if (fileName === undefined) return;
 
 			fs.promises.rm(fileName)
 				.catch((err) => {

--- a/src/executors/PrologExecutor.ts
+++ b/src/executors/PrologExecutor.ts
@@ -17,14 +17,15 @@ export default class PrologExecutor extends Executor {
 	}
 
 	async run(code: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string): Promise<void> {
-		let prologCode = code.split(/\n+%+\s*query\n+/);
+		const prologCode = code.split(/\n+%+\s*query\n+/);
 
 		if (prologCode.length < 2) return;	// no query found
 
 		//Prolog does not support input
 		outputter.closeInput();
+		outputter.clear();
 
-		return this.runPrologCode(prologCode[0], prologCode[1], outputter);
+		this.runPrologCode(prologCode[0], prologCode[1], outputter);
 	}
 
 	async stop() {

--- a/src/executors/python/PythonExecutor.ts
+++ b/src/executors/python/PythonExecutor.ts
@@ -89,8 +89,6 @@ ${this.globalsDictionaryName} = {**globals()}
 				finishSigil
 			);
 
-			console.log(wrappedCode);
-
 			//import print from builtins to circumnavigate the case where the user redefines print
 			this.process.stdin.write(wrappedCode);
 
@@ -105,7 +103,6 @@ ${this.globalsDictionaryName} = {**globals()}
 
 				if (str.endsWith(finishSigil)) {
 					str = str.substring(0, str.length - finishSigil.length);
-					console.log(str);
 
 					this.process.stdout.removeListener("data", writeToStdout)
 					this.process.stderr.removeListener("data", writeToStderr);

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,10 +18,10 @@ import ExecutorManagerView, {
 
 import runAllCodeBlocks from './runAllCodeBlocks';
 
-const languageAliases = ["javascript", "typescript", "bash", "csharp", "wolfram", "nb", "wl", "hs"] as const;
-const canonicalLanguages = ["js", "ts", "cs", "lua", "python", "cpp",
+export const languageAliases = ["javascript", "typescript", "bash", "csharp", "wolfram", "nb", "wl", "hs"] as const;
+export const canonicalLanguages = ["js", "ts", "cs", "lua", "python", "cpp",
 	"prolog", "shell", "groovy", "r", "go", "rust", "java", "powershell", "kotlin", "mathematica", "haskell"] as const;
-const supportedLanguages = [...languageAliases, ...canonicalLanguages] as const;
+export const supportedLanguages = [...languageAliases, ...canonicalLanguages] as const;
 
 
 // type SupportedLanguage = typeof supportedLanguages[number];
@@ -169,8 +169,8 @@ export default class ExecuteCodePlugin extends Plugin {
 				const srcCode = codeBlock.getText();
 
 				const canonicalLanguage = getLanguageAlias(
-					supportedLanguages.find((lang => language.contains(`language-${lang}`)))
-				);
+					supportedLanguages.find(lang => language.contains(`language-${lang}`))
+				) as LanguageId;
 
 				if (canonicalLanguage // if the language is supported
 					&& !parent.classList.contains(hasButtonClass)) { // & this block hasn't been buttonified already

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,6 @@ import {addInlinePlotsToPython, addInlinePlotsToR, addMagicToJS, addMagicToPytho
 
 // @ts-ignore
 import * as prolog from "tau-prolog";
-import NonInteractiveCodeExecutor from './executors/NonInteractiveCodeExecutor';
 import ExecutorContainer from './ExecutorContainer';
 import ExecutorManagerView, {
 	EXECUTOR_MANAGER_OPEN_VIEW_COMMAND_ID,
@@ -240,10 +239,8 @@ export default class ExecuteCodePlugin extends Plugin {
 		} else if (language === "cpp") {
 			button.addEventListener("click", async () => {
 				button.className = runButtonDisabledClass;
-				out.clear();
 				const transformedCode = await new CodeInjector(this.app, this.settings, language).injectCode(srcCode);
 				this.runCode(transformedCode, out, button, this.settings.clingPath, `-std=${this.settings.clingStd} ${this.settings.clingArgs}`, "cpp", language, file);
-				button.className = runButtonClass;
 			});
 
 		} else if (language === "prolog") {
@@ -366,9 +363,7 @@ export default class ExecuteCodePlugin extends Plugin {
 	 * @param file The address of the file which the code originates from
 	 */
 	private runCode(codeBlockContent: string, outputter: Outputter, button: HTMLButtonElement, cmd: string, cmdArgs: string, ext: string, language: LanguageId, file: string) {
-		const executor = this.settings[`${language}Interactive`]
-			? this.executors.getExecutorFor(file, language, false)
-			: new NonInteractiveCodeExecutor(false, file, language);
+		const executor = this.executors.getExecutorFor(file, language, false);
 
 		executor.run(codeBlockContent, outputter, cmd, cmdArgs, ext).then(() => {
 			button.className = runButtonClass;
@@ -390,9 +385,7 @@ export default class ExecuteCodePlugin extends Plugin {
 	 * @param file The address of the file which the code originates from
 	 */
 	private runCodeInShell(codeBlockContent: string, outputter: Outputter, button: HTMLButtonElement, cmd: string, cmdArgs: string, ext: string, language: LanguageId, file: string) {
-		const executor = this.settings[`${language}Interactive`]
-			? this.executors.getExecutorFor(file, language, true)
-			: new NonInteractiveCodeExecutor(true, file, language);
+		const executor = this.executors.getExecutorFor(file, language, true);
 
 		executor.run(codeBlockContent, outputter, cmd, cmdArgs, ext).then(() => {
 			button.className = runButtonClass;

--- a/src/main.ts
+++ b/src/main.ts
@@ -167,7 +167,7 @@ export default class ExecuteCodePlugin extends Plugin {
 				const srcCode = codeBlock.getText();
 
 				const canonicalLanguage = getLanguageAlias(
-					supportedLanguages.find(lang => language.contains(`language-${lang}`))
+					supportedLanguages.find(lang => codeBlock.classList.contains(`language-${lang}`))
 				) as LanguageId;
 
 				if (canonicalLanguage // if the language is supported

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -47,6 +47,7 @@ export interface ExecutorSettings {
 	rustInject: string;
 	cppRunner: string;
 	cppInject: string;
+	cppUseMain: boolean;
 	clingPath: string;
 	clingArgs: string;
 	clingStd: string;
@@ -137,6 +138,7 @@ export const DEFAULT_SETTINGS: ExecutorSettings = {
 	rustInject: "",
 	cppRunner: "cling",
 	cppInject: "",
+	cppUseMain: false,
 	clingPath: "cling",
 	clingArgs: "",
 	clingStd: "c++17",

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -219,8 +219,7 @@ export class SettingsTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.pythonInteractive = value;
 					await this.plugin.saveSettings();
-				})
-			)
+				}));
 		this.makeInjectSetting("python", "Python");
 
 
@@ -288,6 +287,16 @@ export class SettingsTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.clingStd = value;
 					console.log('Cling std set to: ' + value);
+					await this.plugin.saveSettings();
+				}));
+		new Setting(containerEl)
+			.setName('Use main function')
+			.setDesc('If enabled, will use a main() function as the code block entrypoint.')
+			.addToggle((toggle) => toggle
+				.setValue(this.plugin.settings.cppUseMain)
+				.onChange(async (value) => {
+					this.plugin.settings.cppUseMain = value;
+					console.log('Cpp use main set to: ' + value);
 					await this.plugin.saveSettings();
 				}));
 		this.makeInjectSetting("cpp", "C++");

--- a/src/transforms/Magic.ts
+++ b/src/transforms/Magic.ts
@@ -153,7 +153,6 @@ function jsParseShowImage(source: string): string {
 
 		const image = buildMagicShowImage(imagePath.replace(/\\/g, "\\\\"), width, height, alignment);
 		source = source.replace(match[0], "console.log(\'" + image + "\')");
-		console.log(source);
 	}
 
 	return source;

--- a/src/transforms/TransformCode.ts
+++ b/src/transforms/TransformCode.ts
@@ -1,5 +1,6 @@
 import {insertNotePath, insertNoteTitle, insertVaultPath} from "./Magic";
 import {getVaultVariables} from "src/Vault";
+import {canonicalLanguages} from 'src/main';
 import type {App} from "obsidian";
 import type {LanguageId} from "src/main";
 
@@ -9,9 +10,9 @@ import type {LanguageId} from "src/main";
  * @param language A language name or shortcut (e.g. 'js', 'python' or 'shell').
  * @returns The same language shortcut for every alias of the language.
  */
-export function getLanguageAlias(language: string): LanguageId {
-	if (language === undefined) return;
-	return language
+export function getLanguageAlias(language: string | undefined): LanguageId | undefined {
+	if (language === undefined) return undefined;
+	const replaced = language
 		.replace("javascript", "js")
 		.replace("typescript", "ts")
 		.replace("csharp", "cs")
@@ -20,6 +21,9 @@ export function getLanguageAlias(language: string): LanguageId {
 		.replace("nb", "mathematica")
 		.replace("wl", "mathematica")
 		.replace("hs", "haskell") as LanguageId;
+	if (canonicalLanguages.includes(replaced))
+		return replaced;
+	return undefined;
 }
 
 /**


### PR DESCRIPTION
It would be good to remove the large if else chain when running code, so to work towards the ideas in https://github.com/twibiral/obsidian-execute-code/pull/78#discussion_r985787679, I've decoupled executors from interactive mode. There's now 2 objects that map language ids to executors for both interactive and non-interactive executors. If the language is set to interactive mode, it will try to find an interactive executor for that language (this must exist in the object: if the language has the ability to have interactivity turned on, then there must be an interactive executor for that language), otherwise it will try to find a non-interactive executor, and if that fails, it will fall back to the default non-interactive executor. I tried this new approach because the previous implementation was too tightly coupled with interactive mode, and the workaround to get prolog working with `isAlwaysInteractive` from https://github.com/twibiral/obsidian-execute-code/pull/98/files#diff-86f4233ec55f1257a4d362348a3301268d5b7bb3c13bf52e9afabd3dbbb523b6R87 didn't look very maintainable.

Going forward, this lets us remove the if else chain, and for the languages that require only a bit of extra work before running, we could create a single file to hold multiple executor classes for these languages, and because these executors would be small, putting them in a single file would help hide the boilerplate but would remain maintainable.

I've also given c++ it's own executor which now does all the work for running c++, removing the need for extra work in `NonInteractiveCodeExecutor`. This also let me add the option to run c++ code without the need for a main function.