### PR TITLE
Fix JS notebook mode freezing when global injection is used

### DIFF
--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -36,7 +36,7 @@ export default class PythonExecutor extends AsyncExecutor {
 	}
 
 	/**
-	 * Swallows and does not output the "Welcome to Node.js v..." message that shows at startup
+	 * Writes a single newline to ensure that the stdin is set up correctly.
 	 */
 	async dismissIntroMessage() {
 		this.process.stdin.write("\n");

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -39,19 +39,7 @@ export default class PythonExecutor extends AsyncExecutor {
 	 * Swallows and does not output the "Welcome to Node.js v..." message that shows at startup
 	 */
 	async dismissIntroMessage() {
-		// TODO: Does the reject need to be handled? Otherwise it might be removed.
-		this.addJobToQueue((resolve, reject) => {
-			let stdoutBuffers = 0;
-			const listener = () => {
-				//we need 2 data messages: 1 for the welcome message, 1 for the prompt.
-				stdoutBuffers++;
-				if (stdoutBuffers >= 2) {
-					this.process.stdout.removeListener("data", listener);
-					resolve();
-				}
-			}
-			this.process.stdout.on("data", listener);
-		});
+		this.process.stdin.write("\n");
 	}
 
 	/**

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -1,6 +1,6 @@
-import {ChildProcessWithoutNullStreams, spawn} from "child_process";
-import {Outputter} from "src/Outputter";
-import {ExecutorSettings} from "src/settings/Settings";
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+import { Outputter } from "src/Outputter";
+import { ExecutorSettings } from "src/settings/Settings";
 import AsyncExecutor from "./AsyncExecutor";
 
 
@@ -18,7 +18,7 @@ export default class PythonExecutor extends AsyncExecutor {
 		this.process = spawn(settings.nodePath, args);
 
 		//send a newline so that the intro message won't be buffered
-		this.dismissIntroMessage().then(() => {/* do nothing */});
+		this.dismissIntroMessage().then(() => {/* do nothing */ });
 	}
 
 	/**
@@ -59,39 +59,39 @@ export default class PythonExecutor extends AsyncExecutor {
 			try { eval(${JSON.stringify(code)}); } catch(e) { console.error(e); }
 			process.stdout.write(${JSON.stringify(finishSigil)})&&undefined;
 			`;
-			
+
 			outputter.clear();
 
 			this.process.stdin.write(wrappedCode);
 
 
-				outputter.on("data", (data: string) => {
-					this.process.stdin.write(data);
-				});
-
-				const writeToStderr = (data: any) => {
-					outputter.writeErr(data.toString());
-				};
-
-				const writeToStdout = (data: any) => {
-					const stringData = data.toString();
-
-					if (stringData.endsWith(finishSigil)) {
-						outputter.write(
-							stringData.substring(0, stringData.length - finishSigil.length)
-						);
-						
-						this.process.stdout.removeListener("data", writeToStdout);
-						this.process.stderr.removeListener("data", writeToStderr);
-						resolve();
-					} else {
-						outputter.write(stringData);
-					}
-				}
-
-				this.process.stdout.on("data", writeToStdout);
-				this.process.stderr.on("data", writeToStderr);
+			outputter.on("data", (data: string) => {
+				this.process.stdin.write(data);
 			});
+
+			const writeToStderr = (data: any) => {
+				outputter.writeErr(data.toString());
+			};
+
+			const writeToStdout = (data: any) => {
+				const stringData = data.toString();
+
+				if (stringData.endsWith(finishSigil)) {
+					outputter.write(
+						stringData.substring(0, stringData.length - finishSigil.length)
+					);
+
+					this.process.stdout.removeListener("data", writeToStdout);
+					this.process.stderr.removeListener("data", writeToStderr);
+					resolve();
+				} else {
+					outputter.write(stringData);
+				}
+			}
+
+			this.process.stdout.on("data", writeToStdout);
+			this.process.stderr.on("data", writeToStderr);
+		});
 	}
 
 }

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -13,7 +13,7 @@ export default class PythonExecutor extends AsyncExecutor {
 
 		const args = settings.nodeArgs ? settings.nodeArgs.split(" ") : [];
 
-		args.unshift(`-e`, `require("repl").start({prompt: ""})`);
+		args.unshift(`-e`, `require("repl").start({prompt: "", preview: false, ignoreUndefined: true})`);
 
 		this.process = spawn(settings.nodePath, args);
 
@@ -57,7 +57,7 @@ export default class PythonExecutor extends AsyncExecutor {
 
 			const wrappedCode = `
 			try { eval(${JSON.stringify(code)}); } catch(e) { console.error(e); }
-			process.stdout.write(${JSON.stringify(finishSigil)});
+			process.stdout.write(${JSON.stringify(finishSigil)})&&undefined;
 			`;
 			
 			outputter.clear();

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -13,7 +13,7 @@ export default class PythonExecutor extends AsyncExecutor {
 
 		const args = settings.nodeArgs ? settings.nodeArgs.split(" ") : [];
 
-		args.unshift("-i");
+		args.unshift(`-e`, `require("repl").start()`);
 
 		this.process = spawn(settings.nodePath, args);
 

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -13,7 +13,7 @@ export default class PythonExecutor extends AsyncExecutor {
 
 		const args = settings.nodeArgs ? settings.nodeArgs.split(" ") : [];
 
-		args.unshift(`-e`, `require("repl").start()`);
+		args.unshift(`-e`, `require("repl").start({prompt: ""})`);
 
 		this.process = spawn(settings.nodePath, args);
 

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -13,7 +13,7 @@ export default class PythonExecutor extends AsyncExecutor {
 
 		const args = settings.nodeArgs ? settings.nodeArgs.split(" ") : [];
 
-		args.unshift(`-e`, `require("repl").start({prompt: "", preview: false, ignoreUndefined: true})`);
+		args.unshift(`-e`, `require("repl").start({prompt: "", preview: false, ignoreUndefined: true}).on("exit", ()=>process.exit())`);
 
 		this.process = spawn(settings.nodePath, args);
 

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -66,12 +66,11 @@ export default class PythonExecutor extends AsyncExecutor {
 	async run(code: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string) {
 		return this.addJobToQueue((resolve, reject) => {
 
-			const trimmedCode = code.trim() + "\n";
-			this.process.stdin.write(trimmedCode, () => {
-				let prompts = 0;
-				const requiredPrompts = Array.from(trimmedCode.matchAll(/\n/g)).length;
-
-				outputter.clear();
+			const wrappedCode = `
+			try { eval(${JSON.stringify(code)}); } catch(e) { console.error(e); }
+			`;
+			
+			outputter.clear();
 
 				outputter.on("data", (data: string) => {
 					this.process.stdin.write(data);


### PR DESCRIPTION
Refactored the JS executor to be more similar to Python's:
- use `eval()` instead of directly entering code into the REPL
- use a sigil instead of watching for the REPL's prompts

Also used Node.JS's built-in `repl` module to customize the process: we can now ignore undefined expressions, so `console.log(3)` will print *just* `3`, instead of `3` `undefined`

This closes #109 