### PR TITLE
Show One Language-Specific Setting Group at a Time

### DIFF
--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -1,5 +1,22 @@
 import {App, PluginSettingTab, Setting} from "obsidian";
 import ExecuteCodePlugin, {LanguageId} from "src/main";
+import makeCppSettings from "./per-lang/makeCppSettings";
+import makeCsSettings from "./per-lang/makeCsSettings";
+import makeGoSettings from "./per-lang/makeGoSettings";
+import makeGroovySettings from "./per-lang/makeGroovySettings";
+import makeHaskellSettings from "./per-lang/makeHaskellSettings";
+import makeJavaSettings from "./per-lang/makeJavaSettings";
+import makeJsSettings from "./per-lang/makeJsSettings";
+import makeKotlinSettings from "./per-lang/makeKotlinSettings";
+import makeLuaSettings from "./per-lang/makeLuaSettings";
+import makeMathematicaSettings from "./per-lang/makeMathematicaSettings";
+import makePowershellSettings from "./per-lang/makePowershellSettings";
+import makePrologSettings from "./per-lang/makePrologSettings";
+import makePythonSettings from "./per-lang/makePythonSettings";
+import makeRSettings from "./per-lang/makeRSettings";
+import makeRustSettings from "./per-lang/makeRustSettings";
+import makeShellSettings from "./per-lang/makeShellSettings";
+import makeTsSettings from "./per-lang/makeTsSettings";
 import {ExecutorSettings} from "./Settings";
 
 
@@ -56,474 +73,69 @@ export class SettingsTab extends PluginSettingTab {
 
 
 		// ========== JavaScript / Node ==========
-		containerEl.createEl('h3', {text: 'JavaScript / Node Settings'});
-		new Setting(containerEl)
-			.setName('Node path')
-			.addText(text => text
-				.setValue(this.plugin.settings.nodePath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.nodePath = sanitized;
-					console.log('Node path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Node arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.nodeArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.nodeArgs = value;
-					console.log('Node args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName("Run Javascript blocks in Notebook Mode")
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.jsInteractive)
-				.onChange(async (value) => {
-					this.plugin.settings.jsInteractive = value;
-					await this.plugin.saveSettings();
-				})
-			)
-		this.makeInjectSetting("js", "JavaScript");
+		makeJsSettings(this, containerEl);
 
 		// ========== TypeScript ==========
-		containerEl.createEl('h3', {text: 'TypeScript Settings'});
-		new Setting(containerEl)
-			.setName('ts-node path')
-			.addText(text => text
-				.setValue(this.plugin.settings.tsPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.tsPath = sanitized;
-					console.log('ts-node path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('TypeScript arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.tsArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.tsArgs = value;
-					console.log('TypeScript args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("ts", "TypeScript");
+		makeTsSettings(this, containerEl);
 
 		// ========== Lua ==========
-		containerEl.createEl('h3', {text: 'Lua Settings'});
-		new Setting(containerEl)
-			.setName('lua path')
-			.addText(text => text
-				.setValue(this.plugin.settings.luaPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.luaPath = sanitized;
-					console.log('lua path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Lua arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.luaArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.luaArgs = value;
-					console.log('Lua args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("lua", "Lua");
+		makeLuaSettings(this, containerEl);
 
 		// ========== CSharp ==========
-		containerEl.createEl('h3', {text: 'CSharp Settings'});
-		new Setting(containerEl)
-			.setName('dotnet path')
-			.addText(text => text
-				.setValue(this.plugin.settings.csPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.csPath = sanitized;
-					console.log('dotnet path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('CSharp arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.csArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.csArgs = value;
-					console.log('CSharp args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("cs", "CSharp");
+		makeCsSettings(this, containerEl);
 
 		// ========== Java ==========
-		containerEl.createEl('h3', {text: 'Java Settings'});
-		new Setting(containerEl)
-			.setName('Java path (Java 11 or higher)')
-			.setDesc('The path to your Java installation.')
-			.addText(text => text
-				.setValue(this.plugin.settings.javaPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.javaPath = sanitized;
-					console.log('Java path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Java arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.javaArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.javaArgs = value;
-					console.log('Java args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("java", "Java");
+		makeJavaSettings(this, containerEl);
 
 
 		// ========== Python ==========
-		containerEl.createEl('h3', {text: 'Python Settings'});
-		new Setting(containerEl)
-			.setName('Embed Python Plots')
-			.addToggle(toggle => toggle
-				.setValue(this.plugin.settings.pythonEmbedPlots)
-				.onChange(async (value) => {
-					this.plugin.settings.pythonEmbedPlots = value;
-					console.log(value ? 'Embedding Plots into Notes.' : "Not embedding Plots into Notes.");
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Python path')
-			.setDesc('The path to your Python installation.')
-			.addText(text => text
-				.setValue(this.plugin.settings.pythonPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.pythonPath = sanitized;
-					console.log('Python path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Python arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.pythonArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.pythonArgs = value;
-					console.log('Python args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName("Run Python blocks in Notebook Mode")
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.pythonInteractive)
-				.onChange(async (value) => {
-					this.plugin.settings.pythonInteractive = value;
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("python", "Python");
+		makePythonSettings(this, containerEl);
 
 
 		// ========== Golang =========
-		containerEl.createEl('h3', {text: 'Golang Settings'});
-		new Setting(containerEl)
-			.setName('Golang Path')
-			.setDesc('The path to your Golang installation.')
-			.addText(text => text
-				.setValue(this.plugin.settings.golangPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.golangPath = sanitized;
-					console.log('Golang path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("go", "Golang");
+		makeGoSettings(this, containerEl);
 
 
 		// ========== Rust ===========
-		containerEl.createEl('h3', {text: 'Rust Settings'});
-		new Setting(containerEl)
-			.setName('Cargo Path')
-			.setDesc('The path to your Cargo installation.')
-			.addText(text => text
-				.setValue(this.plugin.settings.cargoPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.cargoPath = sanitized;
-					console.log('Cargo path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("rust", "Rust");
+		makeRustSettings(this, containerEl);
 
 
 		// ========== C++ ===========
-		containerEl.createEl('h3', {text: 'C++ Settings'});
-		new Setting(containerEl)
-			.setName('Cling path')
-			.setDesc('The path to your Cling installation.')
-			.addText(text => text
-				.setValue(this.plugin.settings.clingPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.clingPath = sanitized;
-					console.log('Cling path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Cling arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.clingArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.clingArgs = value;
-					console.log('Cling args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Cling std')
-			.addDropdown(dropdown => dropdown
-				.addOption('c++11', 'C++ 11')
-				.addOption('c++14', 'C++ 14')
-				.addOption('c++17', 'C++ 17')
-				.setValue(this.plugin.settings.clingStd)
-				.onChange(async (value) => {
-					this.plugin.settings.clingStd = value;
-					console.log('Cling std set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Use main function')
-			.setDesc('If enabled, will use a main() function as the code block entrypoint.')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.cppUseMain)
-				.onChange(async (value) => {
-					this.plugin.settings.cppUseMain = value;
-					console.log('Cpp use main set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("cpp", "C++");
+		makeCppSettings(this, containerEl);
 
 
 		// ========== Shell ==========
-		containerEl.createEl('h3', {text: 'Shell Settings'});
-		new Setting(containerEl)
-			.setName('Shell path')
-			.setDesc('The path to shell. Default is Bash but you can use any shell you want, e.g. bash, zsh, fish, ...')
-			.addText(text => text
-				.setValue(this.plugin.settings.shellPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.shellPath = sanitized;
-					console.log('Shell path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Shell arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.shellArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.shellArgs = value;
-					console.log('Shell args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Shell file extension')
-			.setDesc('Changes the file extension for generated shell scripts. This is useful if you want to use a shell other than bash.')
-			.addText(text => text
-				.setValue(this.plugin.settings.shellFileExtension)
-				.onChange(async (value) => {
-					this.plugin.settings.shellFileExtension = value;
-					console.log('Shell file extension set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("shell", "Shell");
+		makeShellSettings(this, containerEl);
 
 
 		// ========== Powershell ==========
-		containerEl.createEl('h3', {text: 'Powershell Settings'});
-		new Setting(containerEl)
-			.setName('Powershell path')
-			.setDesc('The path to Powershell.')
-			.addText(text => text
-				.setValue(this.plugin.settings.powershellPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.powershellPath = sanitized;
-					console.log('Powershell path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Shell arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.powershellArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.powershellArgs = value;
-					console.log('Powershell args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Shell file extension')
-			.setDesc('Changes the file extension for generated shell scripts. This is useful if you want to use a shell other than bash.')
-			.addText(text => text
-				.setValue(this.plugin.settings.powershellFileExtension)
-				.onChange(async (value) => {
-					this.plugin.settings.powershellFileExtension = value;
-					console.log('Powershell file extension set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("powershell", "Powershell");
+		makePowershellSettings(this, containerEl);
 
 
 		// ========== Prolog ==========
-		containerEl.createEl('h3', {text: 'Prolog Settings'});
-		new Setting(containerEl)
-			.setName('Prolog Answer Limit')
-			.setDesc('Maximal number of answers to be returned by the Prolog engine. This is to prevent creating too huge texts in the notebook.')
-			.addText(text => text
-				.setValue("" + this.plugin.settings.maxPrologAnswers)
-				.onChange(async (value) => {
-					if (Number(value) * 1000) {
-						console.log('Prolog answer limit set to: ' + value);
-						this.plugin.settings.maxPrologAnswers = Number(value);
-					}
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("prolog", "Prolog");
+		makePrologSettings(this, containerEl);
 
 
 		// ========== Groovy ==========
-		containerEl.createEl('h3', {text: 'Groovy Settings'});
-		new Setting(containerEl)
-			.setName('Groovy path')
-			.setDesc('The path to your Groovy installation.')
-			.addText(text => text
-				.setValue(this.plugin.settings.groovyPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.groovyPath = sanitized;
-					console.log('Groovy path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Groovy arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.groovyArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.groovyArgs = value;
-					console.log('Groovy args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("groovy", "Groovy");
+		makeGroovySettings(this, containerEl);
 
 
 		// ========== R ==========
-		containerEl.createEl('h3', {text: 'R Settings'});
-		new Setting(containerEl)
-			.setName('Embed R Plots created via `plot()` into Notes')
-			.addToggle(toggle => toggle
-				.setValue(this.plugin.settings.REmbedPlots)
-				.onChange(async (value) => {
-					this.plugin.settings.REmbedPlots = value;
-					console.log(value ? 'Embedding R Plots into Notes.' : "Not embedding R Plots into Notes.");
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Rscript path')
-			.setDesc('The path to your Rscript installation. Ensure you provide the Rscript binary instead of the ordinary R binary.')
-			.addText(text => text
-				.setValue(this.plugin.settings.RPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.RPath = sanitized;
-					console.log('R path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('R arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.RArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.RArgs = value;
-					console.log('R args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("r", "R");
+		makeRSettings(this, containerEl);
 
 
 		// ========== Kotlin ==========
-		containerEl.createEl('h3', {text: 'Kotlin Settings'});
-		new Setting(containerEl)
-			.setName('Kotlin path')
-			.setDesc('The path to your Kotlin installation.')
-			.addText(text => text
-				.setValue(this.plugin.settings.kotlinPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.kotlinPath = sanitized;
-					console.log('Kotlin path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Kotlin arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.kotlinArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.kotlinArgs = value;
-					console.log('Kotlin args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("kotlin", "Kotlin");
+		makeKotlinSettings(this, containerEl);
 
 		// ========== Mathematica ==========
-		containerEl.createEl('h3', {text: 'Wolfram Mathematica Settings'});
-		new Setting(containerEl)
-			.setName('Mathematica path')
-			.setDesc('The path to your Mathematica installation.')
-			.addText(text => text
-				.setValue(this.plugin.settings.kotlinPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.mathematicaPath = sanitized;
-					console.log('Mathematica path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Mathematica arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.kotlinArgs)
-				.onChange(async (value) => {
-					this.plugin.settings.mathematicaArgs = value;
-					console.log('Kotlin args set to: ' + value);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("mathematica", "Mathematica");
+		makeMathematicaSettings(this, containerEl);
 
 
 		// ========== Haskell ===========
-		containerEl.createEl('h3', {text: 'Haskell Settings'});
-		new Setting(containerEl)
-			.setName('Ghci path')
-			.setDesc('The path to your Ghci installation.')
-			.addText(text => text
-				.setValue(this.plugin.settings.ghciPath)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.ghciPath = sanitized;
-					console.log('Ghci path set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		new Setting(containerEl)
-			.setName('Ghci arguments')
-			.addText(text => text
-				.setValue(this.plugin.settings.ghciArgs)
-				.onChange(async (value) => {
-					const sanitized = this.sanitizePath(value);
-					this.plugin.settings.ghciArgs = sanitized;
-					console.log('Ghci args set to: ' + sanitized);
-					await this.plugin.saveSettings();
-				}));
-		this.makeInjectSetting("haskell", "Haskell");
+		makeHaskellSettings(this, containerEl);
 	}
 
-	private sanitizePath(path: string): string {
+	sanitizePath(path: string): string {
 		path = path.replace(/\\/g, '/');
 		path = path.replace(/['"`]/, '');
 		path = path.trim();
@@ -531,7 +143,7 @@ export class SettingsTab extends PluginSettingTab {
 		return path
 	}
 
-	private makeInjectSetting(language: LanguageId, languageAlt: string) {
+	makeInjectSetting(language: LanguageId, languageAlt: string) {
 		new Setting(this.containerEl)
 			.setName(`Inject ${languageAlt} code`)
 			.setDesc(`Code to add to the top of every ${languageAlt} code block before running.`)

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -143,8 +143,8 @@ export class SettingsTab extends PluginSettingTab {
 		return path
 	}
 
-	makeInjectSetting(language: LanguageId, languageAlt: string) {
-		new Setting(this.containerEl)
+	makeInjectSetting(containerEl: HTMLElement, language: LanguageId, languageAlt: string) {
+		new Setting(containerEl)
 			.setName(`Inject ${languageAlt} code`)
 			.setDesc(`Code to add to the top of every ${languageAlt} code block before running.`)
 			.setClass('settings-code-input-box')

--- a/src/settings/per-lang/makeCppSettings.ts
+++ b/src/settings/per-lang/makeCppSettings.ts
@@ -1,0 +1,49 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'C++ Settings' });
+    new Setting(containerEl)
+        .setName('Cling path')
+        .setDesc('The path to your Cling installation.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.clingPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.clingPath = sanitized;
+                console.log('Cling path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Cling arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.clingArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.clingArgs = value;
+                console.log('Cling args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Cling std')
+        .addDropdown(dropdown => dropdown
+            .addOption('c++11', 'C++ 11')
+            .addOption('c++14', 'C++ 14')
+            .addOption('c++17', 'C++ 17')
+            .setValue(tab.plugin.settings.clingStd)
+            .onChange(async (value) => {
+                tab.plugin.settings.clingStd = value;
+                console.log('Cling std set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Use main function')
+        .setDesc('If enabled, will use a main() function as the code block entrypoint.')
+        .addToggle((toggle) => toggle
+            .setValue(tab.plugin.settings.cppUseMain)
+            .onChange(async (value) => {
+                tab.plugin.settings.cppUseMain = value;
+                console.log('Cpp use main set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("cpp", "C++");
+}

--- a/src/settings/per-lang/makeCppSettings.ts
+++ b/src/settings/per-lang/makeCppSettings.ts
@@ -45,5 +45,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('Cpp use main set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("cpp", "C++");
+    tab.makeInjectSetting(containerEl, "cpp", "C++");
 }

--- a/src/settings/per-lang/makeCsSettings.ts
+++ b/src/settings/per-lang/makeCsSettings.ts
@@ -1,0 +1,26 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'CSharp Settings' });
+    new Setting(containerEl)
+        .setName('dotnet path')
+        .addText(text => text
+            .setValue(tab.plugin.settings.csPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.csPath = sanitized;
+                console.log('dotnet path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('CSharp arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.csArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.csArgs = value;
+                console.log('CSharp args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("cs", "CSharp");
+}

--- a/src/settings/per-lang/makeCsSettings.ts
+++ b/src/settings/per-lang/makeCsSettings.ts
@@ -22,5 +22,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('CSharp args set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("cs", "CSharp");
+    tab.makeInjectSetting(containerEl, "cs", "CSharp");
 }

--- a/src/settings/per-lang/makeGoSettings.ts
+++ b/src/settings/per-lang/makeGoSettings.ts
@@ -1,0 +1,18 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Golang Settings' });
+    new Setting(containerEl)
+        .setName('Golang Path')
+        .setDesc('The path to your Golang installation.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.golangPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.golangPath = sanitized;
+                console.log('Golang path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("go", "Golang");
+}

--- a/src/settings/per-lang/makeGoSettings.ts
+++ b/src/settings/per-lang/makeGoSettings.ts
@@ -14,5 +14,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('Golang path set to: ' + sanitized);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("go", "Golang");
+    tab.makeInjectSetting(containerEl, "go", "Golang");
 }

--- a/src/settings/per-lang/makeGroovySettings.ts
+++ b/src/settings/per-lang/makeGroovySettings.ts
@@ -23,5 +23,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('Groovy args set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("groovy", "Groovy");
+    tab.makeInjectSetting(containerEl, "groovy", "Groovy");
 }

--- a/src/settings/per-lang/makeGroovySettings.ts
+++ b/src/settings/per-lang/makeGroovySettings.ts
@@ -1,0 +1,27 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Groovy Settings' });
+    new Setting(containerEl)
+        .setName('Groovy path')
+        .setDesc('The path to your Groovy installation.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.groovyPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.groovyPath = sanitized;
+                console.log('Groovy path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Groovy arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.groovyArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.groovyArgs = value;
+                console.log('Groovy args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("groovy", "Groovy");
+}

--- a/src/settings/per-lang/makeHaskellSettings.ts
+++ b/src/settings/per-lang/makeHaskellSettings.ts
@@ -24,5 +24,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('Ghci args set to: ' + sanitized);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("haskell", "Haskell");
+    tab.makeInjectSetting(containerEl, "haskell", "Haskell");
 }

--- a/src/settings/per-lang/makeHaskellSettings.ts
+++ b/src/settings/per-lang/makeHaskellSettings.ts
@@ -1,0 +1,28 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Haskell Settings' });
+    new Setting(containerEl)
+        .setName('Ghci path')
+        .setDesc('The path to your Ghci installation.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.ghciPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.ghciPath = sanitized;
+                console.log('Ghci path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Ghci arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.ghciArgs)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.ghciArgs = sanitized;
+                console.log('Ghci args set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("haskell", "Haskell");
+}

--- a/src/settings/per-lang/makeJavaSettings.ts
+++ b/src/settings/per-lang/makeJavaSettings.ts
@@ -23,5 +23,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('Java args set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("java", "Java");
+    tab.makeInjectSetting(containerEl, "java", "Java");
 }

--- a/src/settings/per-lang/makeJavaSettings.ts
+++ b/src/settings/per-lang/makeJavaSettings.ts
@@ -1,0 +1,27 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Java Settings' });
+    new Setting(containerEl)
+        .setName('Java path (Java 11 or higher)')
+        .setDesc('The path to your Java installation.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.javaPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.javaPath = sanitized;
+                console.log('Java path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Java arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.javaArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.javaArgs = value;
+                console.log('Java args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("java", "Java");
+}

--- a/src/settings/per-lang/makeJsSettings.ts
+++ b/src/settings/per-lang/makeJsSettings.ts
@@ -1,0 +1,35 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'JavaScript / Node Settings' });
+    new Setting(containerEl)
+        .setName('Node path')
+        .addText(text => text
+            .setValue(tab.plugin.settings.nodePath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.nodePath = sanitized;
+                console.log('Node path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Node arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.nodeArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.nodeArgs = value;
+                console.log('Node args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName("Run Javascript blocks in Notebook Mode")
+        .addToggle((toggle) => toggle
+            .setValue(tab.plugin.settings.jsInteractive)
+            .onChange(async (value) => {
+                tab.plugin.settings.jsInteractive = value;
+                await tab.plugin.saveSettings();
+            })
+        )
+    tab.makeInjectSetting("js", "JavaScript");
+}

--- a/src/settings/per-lang/makeJsSettings.ts
+++ b/src/settings/per-lang/makeJsSettings.ts
@@ -31,5 +31,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 await tab.plugin.saveSettings();
             })
         )
-    tab.makeInjectSetting("js", "JavaScript");
+    tab.makeInjectSetting(containerEl, "js", "JavaScript");
 }

--- a/src/settings/per-lang/makeKotlinSettings.ts
+++ b/src/settings/per-lang/makeKotlinSettings.ts
@@ -1,0 +1,27 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Kotlin Settings' });
+    new Setting(containerEl)
+        .setName('Kotlin path')
+        .setDesc('The path to your Kotlin installation.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.kotlinPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.kotlinPath = sanitized;
+                console.log('Kotlin path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Kotlin arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.kotlinArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.kotlinArgs = value;
+                console.log('Kotlin args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("kotlin", "Kotlin");
+}

--- a/src/settings/per-lang/makeKotlinSettings.ts
+++ b/src/settings/per-lang/makeKotlinSettings.ts
@@ -23,5 +23,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('Kotlin args set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("kotlin", "Kotlin");
+    tab.makeInjectSetting(containerEl, "kotlin", "Kotlin");
 }

--- a/src/settings/per-lang/makeLuaSettings.ts
+++ b/src/settings/per-lang/makeLuaSettings.ts
@@ -22,5 +22,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('Lua args set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("lua", "Lua");
+    tab.makeInjectSetting(containerEl, "lua", "Lua");
 }

--- a/src/settings/per-lang/makeLuaSettings.ts
+++ b/src/settings/per-lang/makeLuaSettings.ts
@@ -1,0 +1,26 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Lua Settings' });
+    new Setting(containerEl)
+        .setName('lua path')
+        .addText(text => text
+            .setValue(tab.plugin.settings.luaPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.luaPath = sanitized;
+                console.log('lua path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Lua arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.luaArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.luaArgs = value;
+                console.log('Lua args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("lua", "Lua");
+}

--- a/src/settings/per-lang/makeMathematicaSettings.ts
+++ b/src/settings/per-lang/makeMathematicaSettings.ts
@@ -23,5 +23,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('Kotlin args set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("mathematica", "Mathematica");
+    tab.makeInjectSetting(containerEl, "mathematica", "Mathematica");
 }

--- a/src/settings/per-lang/makeMathematicaSettings.ts
+++ b/src/settings/per-lang/makeMathematicaSettings.ts
@@ -1,0 +1,27 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Wolfram Mathematica Settings' });
+    new Setting(containerEl)
+        .setName('Mathematica path')
+        .setDesc('The path to your Mathematica installation.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.kotlinPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.mathematicaPath = sanitized;
+                console.log('Mathematica path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Mathematica arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.kotlinArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.mathematicaArgs = value;
+                console.log('Kotlin args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("mathematica", "Mathematica");
+}

--- a/src/settings/per-lang/makePowershellSettings.ts
+++ b/src/settings/per-lang/makePowershellSettings.ts
@@ -33,5 +33,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('Powershell file extension set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("powershell", "Powershell");
+    tab.makeInjectSetting(containerEl, "powershell", "Powershell");
 }

--- a/src/settings/per-lang/makePowershellSettings.ts
+++ b/src/settings/per-lang/makePowershellSettings.ts
@@ -1,0 +1,37 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Powershell Settings' });
+    new Setting(containerEl)
+        .setName('Powershell path')
+        .setDesc('The path to Powershell.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.powershellPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.powershellPath = sanitized;
+                console.log('Powershell path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Shell arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.powershellArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.powershellArgs = value;
+                console.log('Powershell args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Shell file extension')
+        .setDesc('Changes the file extension for generated shell scripts. This is useful if you want to use a shell other than bash.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.powershellFileExtension)
+            .onChange(async (value) => {
+                tab.plugin.settings.powershellFileExtension = value;
+                console.log('Powershell file extension set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("powershell", "Powershell");
+}

--- a/src/settings/per-lang/makePrologSettings.ts
+++ b/src/settings/per-lang/makePrologSettings.ts
@@ -15,5 +15,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 }
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("prolog", "Prolog");
+    tab.makeInjectSetting(containerEl, "prolog", "Prolog");
 }

--- a/src/settings/per-lang/makePrologSettings.ts
+++ b/src/settings/per-lang/makePrologSettings.ts
@@ -1,0 +1,19 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Prolog Settings' });
+    new Setting(containerEl)
+        .setName('Prolog Answer Limit')
+        .setDesc('Maximal number of answers to be returned by the Prolog engine. tab is to prevent creating too huge texts in the notebook.')
+        .addText(text => text
+            .setValue("" + tab.plugin.settings.maxPrologAnswers)
+            .onChange(async (value) => {
+                if (Number(value) * 1000) {
+                    console.log('Prolog answer limit set to: ' + value);
+                    tab.plugin.settings.maxPrologAnswers = Number(value);
+                }
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("prolog", "Prolog");
+}

--- a/src/settings/per-lang/makePythonSettings.ts
+++ b/src/settings/per-lang/makePythonSettings.ts
@@ -1,0 +1,44 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Python Settings' });
+    new Setting(containerEl)
+        .setName('Embed Python Plots')
+        .addToggle(toggle => toggle
+            .setValue(tab.plugin.settings.pythonEmbedPlots)
+            .onChange(async (value) => {
+                tab.plugin.settings.pythonEmbedPlots = value;
+                console.log(value ? 'Embedding Plots into Notes.' : "Not embedding Plots into Notes.");
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Python path')
+        .setDesc('The path to your Python installation.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.pythonPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.pythonPath = sanitized;
+                console.log('Python path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Python arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.pythonArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.pythonArgs = value;
+                console.log('Python args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName("Run Python blocks in Notebook Mode")
+        .addToggle((toggle) => toggle
+            .setValue(tab.plugin.settings.pythonInteractive)
+            .onChange(async (value) => {
+                tab.plugin.settings.pythonInteractive = value;
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("python", "Python");
+}

--- a/src/settings/per-lang/makePythonSettings.ts
+++ b/src/settings/per-lang/makePythonSettings.ts
@@ -40,5 +40,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 tab.plugin.settings.pythonInteractive = value;
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("python", "Python");
+    tab.makeInjectSetting(containerEl, "python", "Python");
 }

--- a/src/settings/per-lang/makeRSettings.ts
+++ b/src/settings/per-lang/makeRSettings.ts
@@ -1,0 +1,36 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'R Settings' });
+    new Setting(containerEl)
+        .setName('Embed R Plots created via `plot()` into Notes')
+        .addToggle(toggle => toggle
+            .setValue(tab.plugin.settings.REmbedPlots)
+            .onChange(async (value) => {
+                tab.plugin.settings.REmbedPlots = value;
+                console.log(value ? 'Embedding R Plots into Notes.' : "Not embedding R Plots into Notes.");
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Rscript path')
+        .setDesc('The path to your Rscript installation. Ensure you provide the Rscript binary instead of the ordinary R binary.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.RPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.RPath = sanitized;
+                console.log('R path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('R arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.RArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.RArgs = value;
+                console.log('R args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("r", "R");
+}

--- a/src/settings/per-lang/makeRSettings.ts
+++ b/src/settings/per-lang/makeRSettings.ts
@@ -32,5 +32,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('R args set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("r", "R");
+    tab.makeInjectSetting(containerEl, "r", "R");
 }

--- a/src/settings/per-lang/makeRustSettings.ts
+++ b/src/settings/per-lang/makeRustSettings.ts
@@ -14,5 +14,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('Cargo path set to: ' + sanitized);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("rust", "Rust");
+    tab.makeInjectSetting(containerEl, "rust", "Rust");
 }

--- a/src/settings/per-lang/makeRustSettings.ts
+++ b/src/settings/per-lang/makeRustSettings.ts
@@ -1,0 +1,18 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Rust Settings' });
+    new Setting(containerEl)
+        .setName('Cargo Path')
+        .setDesc('The path to your Cargo installation.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.cargoPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.cargoPath = sanitized;
+                console.log('Cargo path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("rust", "Rust");
+}

--- a/src/settings/per-lang/makeShellSettings.ts
+++ b/src/settings/per-lang/makeShellSettings.ts
@@ -33,5 +33,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('Shell file extension set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("shell", "Shell");
+    tab.makeInjectSetting(containerEl, "shell", "Shell");
 }

--- a/src/settings/per-lang/makeShellSettings.ts
+++ b/src/settings/per-lang/makeShellSettings.ts
@@ -1,0 +1,37 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Shell Settings' });
+    new Setting(containerEl)
+        .setName('Shell path')
+        .setDesc('The path to shell. Default is Bash but you can use any shell you want, e.g. bash, zsh, fish, ...')
+        .addText(text => text
+            .setValue(tab.plugin.settings.shellPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.shellPath = sanitized;
+                console.log('Shell path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Shell arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.shellArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.shellArgs = value;
+                console.log('Shell args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Shell file extension')
+        .setDesc('Changes the file extension for generated shell scripts. This is useful if you want to use a shell other than bash.')
+        .addText(text => text
+            .setValue(tab.plugin.settings.shellFileExtension)
+            .onChange(async (value) => {
+                tab.plugin.settings.shellFileExtension = value;
+                console.log('Shell file extension set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("shell", "Shell");
+}

--- a/src/settings/per-lang/makeTsSettings.ts
+++ b/src/settings/per-lang/makeTsSettings.ts
@@ -22,5 +22,5 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('TypeScript args set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
-    tab.makeInjectSetting("ts", "TypeScript");
+    tab.makeInjectSetting(containerEl, "ts", "TypeScript");
 }

--- a/src/settings/per-lang/makeTsSettings.ts
+++ b/src/settings/per-lang/makeTsSettings.ts
@@ -1,0 +1,26 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'TypeScript Settings' });
+    new Setting(containerEl)
+        .setName('ts-node path')
+        .addText(text => text
+            .setValue(tab.plugin.settings.tsPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.tsPath = sanitized;
+                console.log('ts-node path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('TypeScript arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.tsArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.tsArgs = value;
+                console.log('TypeScript args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting("ts", "TypeScript");
+}


### PR DESCRIPTION
This PR refactors `SettingsTab.ts` from 1 enormous file into 1 main file and several per-language files. 

I then made it so each language gets its own container `<div>`. Only one div gets shown at a time (controlled by a dropdown), so a user can easily find their language's settings.

This closes #91 