### PR TITLE
Update Future Work section

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,6 @@ Do not execute code from sources you don't know or code you don't understand. Ex
 
 - Find better way to show that the program is running (for example a loading sign).
 - Notebook Mode similar to Jupyter
-- Key combination to execute all code blocks in a file
 - Error warning when the execution fails (e.g. when python isn't installed)
 - Test if this plugin works in combination with dataview.
 


### PR DESCRIPTION
This is a tiny PR to remove the 'Key combination to execute all code blocks in a file' item from the Future Work in README.md. We could also remove the "Notebook Mode similar to Jupyter" item, but in my personal opinion, Notebook Mode isn't mature enough for that. Any opinions re: that are welcome.