### PR TITLE
Show indicator when block is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,6 @@ Do not execute code from sources you don't know or code you don't understand. Ex
 
 ## Future Work
 
-- Find better way to show that the program is running (for example a loading sign).
 - Notebook Mode similar to Jupyter
 - Key combination to execute all code blocks in a file
 - Error warning when the execution fails (e.g. when python isn't installed)

--- a/src/Outputter.ts
+++ b/src/Outputter.ts
@@ -16,6 +16,8 @@ export class Outputter extends EventEmitter {
 
 	hadPreviouslyPrinted: boolean;
 	inputState: "NOT_DOING" | "OPEN" | "CLOSED" | "INACTIVE";
+	
+	blockRunState: "RUNNING" | "QUEUED" | "FINISHED" | "INITIAL";
 
 	constructor(codeBlock: HTMLElement, doInput: boolean) {
 		super();
@@ -23,6 +25,7 @@ export class Outputter extends EventEmitter {
 		this.inputState = doInput ? "INACTIVE" : "NOT_DOING";
 		this.codeBlockElement = codeBlock;
 		this.hadPreviouslyPrinted = false;
+		this.blockRunState = "INITIAL";
 	}
 
 	/**
@@ -98,12 +101,18 @@ export class Outputter extends EventEmitter {
 	 */
 	startBlock() {
 		if(!this.loadStateIndicatorElement) this.addLoadStateIndicator();
-		this.loadStateIndicatorElement.classList.add("visible");
+		setTimeout(() => {
+			if(this.blockRunState != "FINISHED") 
+				this.loadStateIndicatorElement.classList.add("visible");	
+		}, 100);
+		
 		
 		this.loadStateIndicatorElement.empty();
 		this.loadStateIndicatorElement.appendChild(loadSpinner());
 		
 		this.loadStateIndicatorElement.setAttribute("aria-label", "This block is running");
+		
+		this.blockRunState = "RUNNING";
 	}
 	
 	/**
@@ -111,12 +120,17 @@ export class Outputter extends EventEmitter {
 	 */
 	queueBlock() {
 		if (!this.loadStateIndicatorElement) this.addLoadStateIndicator();
-		this.loadStateIndicatorElement.classList.add("visible");
+		setTimeout(() => {
+			if (this.blockRunState != "FINISHED")
+				this.loadStateIndicatorElement.classList.add("visible");
+		}, 100);
 		
 		this.loadStateIndicatorElement.empty();
 		this.loadStateIndicatorElement.appendChild(loadEllipses());
 		
 		this.loadStateIndicatorElement.setAttribute("aria-label", "This block is waiting for another block to finish");
+		
+		this.blockRunState = "QUEUED";
 	}
 	
 	/** Marks the block as finished running */
@@ -124,6 +138,8 @@ export class Outputter extends EventEmitter {
 		if (this.loadStateIndicatorElement) {
 			this.loadStateIndicatorElement.classList.remove("visible");
 		}
+		
+		this.blockRunState = "FINISHED";
 	}
 	
 	private addLoadStateIndicator() {

--- a/src/Outputter.ts
+++ b/src/Outputter.ts
@@ -104,7 +104,7 @@ export class Outputter extends EventEmitter {
 		this.loadStateIndicatorElement.empty();
 		this.loadStateIndicatorElement.appendChild(loadSpinner());
 		
-		this.loadStateIndicatorElement.setAttribute("aria-label", "This block is running")
+		this.loadStateIndicatorElement.setAttribute("aria-label", "This block is running");
 	}
 	
 	/**

--- a/src/Outputter.ts
+++ b/src/Outputter.ts
@@ -98,8 +98,7 @@ export class Outputter extends EventEmitter {
 	 */
 	startBlock() {
 		if(!this.loadStateIndicatorElement) this.addLoadStateIndicator();
-		
-		this.loadStateIndicatorElement.style.display = "block";
+		this.loadStateIndicatorElement.classList.add("visible");
 		
 		this.loadStateIndicatorElement.empty();
 		this.loadStateIndicatorElement.appendChild(loadSpinner());
@@ -112,7 +111,7 @@ export class Outputter extends EventEmitter {
 	 */
 	queueBlock() {
 		if (!this.loadStateIndicatorElement) this.addLoadStateIndicator();
-		this.loadStateIndicatorElement.style.display = "block";
+		this.loadStateIndicatorElement.classList.add("visible");
 		
 		this.loadStateIndicatorElement.empty();
 		this.loadStateIndicatorElement.appendChild(loadEllipses());
@@ -123,7 +122,7 @@ export class Outputter extends EventEmitter {
 	/** Marks the block as finished running */
 	finishBlock() {
 		if (this.loadStateIndicatorElement) {
-			this.loadStateIndicatorElement.style.display = "none";
+			this.loadStateIndicatorElement.classList.remove("visible");
 		}
 	}
 	

--- a/src/Outputter.ts
+++ b/src/Outputter.ts
@@ -1,4 +1,5 @@
 import {EventEmitter} from "events";
+import loadSpinner from "./svgs/loadSpinner";
 
 
 export class Outputter extends EventEmitter {
@@ -9,6 +10,8 @@ export class Outputter extends EventEmitter {
 	lastPrinted: string;
 
 	inputElement: HTMLInputElement;
+	
+	loadStateIndicatorElement: HTMLElement;
 
 	hadPreviouslyPrinted: boolean;
 	inputState: "NOT_DOING" | "OPEN" | "CLOSED" | "INACTIVE";
@@ -87,6 +90,31 @@ export class Outputter extends EventEmitter {
 		this.inputState = "CLOSED";
 		if (this.inputElement)
 			this.inputElement.style.display = "none";
+	}
+	
+	startBlock() {
+		if(!this.loadStateIndicatorElement) this.addLoadStateIndicator();
+		
+		this.loadStateIndicatorElement.style.display = "block";
+		
+		this.loadStateIndicatorElement.innerHTML = loadSpinner();
+		
+		this.loadStateIndicatorElement.setAttribute("aria-label", "This block is running")
+	}
+	
+	/** Marks the block as finished running */
+	finishBlock() {
+		if (this.loadStateIndicatorElement) {
+			this.loadStateIndicatorElement.style.display = "none";
+		}
+	}
+	
+	private addLoadStateIndicator() {
+		this.loadStateIndicatorElement = document.createElement("div");
+		
+		this.loadStateIndicatorElement.classList.add("load-state-indicator");
+		
+		this.getParentElement().parentElement.appendChild(this.loadStateIndicatorElement);
 	}
 
 	private getParentElement() {

--- a/src/Outputter.ts
+++ b/src/Outputter.ts
@@ -97,7 +97,8 @@ export class Outputter extends EventEmitter {
 		
 		this.loadStateIndicatorElement.style.display = "block";
 		
-		this.loadStateIndicatorElement.innerHTML = loadSpinner();
+		this.loadStateIndicatorElement.empty();
+		this.loadStateIndicatorElement.appendChild(loadSpinner());
 		
 		this.loadStateIndicatorElement.setAttribute("aria-label", "This block is running")
 	}

--- a/src/Outputter.ts
+++ b/src/Outputter.ts
@@ -92,6 +92,9 @@ export class Outputter extends EventEmitter {
 			this.inputElement.style.display = "none";
 	}
 	
+	/**
+	 * Mark the block as running
+	 */
 	startBlock() {
 		if(!this.loadStateIndicatorElement) this.addLoadStateIndicator();
 		

--- a/src/Outputter.ts
+++ b/src/Outputter.ts
@@ -1,4 +1,5 @@
 import {EventEmitter} from "events";
+import loadEllipses from "./svgs/loadEllipses";
 import loadSpinner from "./svgs/loadSpinner";
 
 
@@ -104,6 +105,19 @@ export class Outputter extends EventEmitter {
 		this.loadStateIndicatorElement.appendChild(loadSpinner());
 		
 		this.loadStateIndicatorElement.setAttribute("aria-label", "This block is running")
+	}
+	
+	/**
+	 * Marks the block as queued, but waiting for another block before running
+	 */
+	queueBlock() {
+		if (!this.loadStateIndicatorElement) this.addLoadStateIndicator();
+		this.loadStateIndicatorElement.style.display = "block";
+		
+		this.loadStateIndicatorElement.empty();
+		this.loadStateIndicatorElement.appendChild(loadEllipses());
+		
+		this.loadStateIndicatorElement.setAttribute("aria-label", "This block is waiting for another block to finish");
 	}
 	
 	/** Marks the block as finished running */

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -64,7 +64,12 @@ export default class PythonExecutor extends AsyncExecutor {
 	 * @returns A promise that resolves once the code is done running
 	 */
 	async run(code: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string) {
+		
+		outputter.queueBlock();
+		
 		return this.addJobToQueue((resolve, reject) => {
+			
+			outputter.startBlock();
 
 			const trimmedCode = code.trim() + "\n";
 			this.process.stdin.write(trimmedCode, () => {

--- a/src/executors/python/PythonExecutor.ts
+++ b/src/executors/python/PythonExecutor.ts
@@ -78,9 +78,13 @@ ${this.globalsDictionaryName} = {**globals()}
 	 * @returns A promise that resolves once the code is done running
 	 */
 	async run(code: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string) {
+		outputter.queueBlock();
+		
 		// TODO: Is handling for reject necessary?
 		return this.addJobToQueue((resolve, reject) => {
 			const finishSigil = `SIGIL_BLOCK_DONE${Math.random()}_${Date.now()}_${code.length}`;
+			
+			outputter.startBlock();
 
 			const wrappedCode = wrapPython(code,
 				this.globalsDictionaryName,

--- a/src/main.ts
+++ b/src/main.ts
@@ -356,10 +356,12 @@ export default class ExecuteCodePlugin extends Plugin {
 	 * @param file The address of the file which the code originates from
 	 */
 	private runCode(codeBlockContent: string, outputter: Outputter, button: HTMLButtonElement, cmd: string, cmdArgs: string, ext: string, language: LanguageId, file: string) {
+		outputter.startBlock();
 		const executor = this.executors.getExecutorFor(file, language, false);
 		executor.run(codeBlockContent, outputter, cmd, cmdArgs, ext).then(() => {
 			button.className = runButtonClass;
 			outputter.closeInput();
+			outputter.finishBlock();
 		});
 	}
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -124,8 +124,9 @@ input.interactive-stdin {
 	background: var(--background-primary-alt);
 	border-top-left-radius: 4px;
 	border-bottom-left-radius: 4px;
-	box-shadow: -1em 0 1em -0.75em inset var(--background-modifier-box-shadow);
 	color: var(--tx1);
+	transform: translateX(2em);
+	transition: transform 0.25s;
 }
 
 .load-state-indicator svg {
@@ -136,4 +137,29 @@ input.interactive-stdin {
 
 .has-run-code-button {
 	position: relative;
+}
+
+.has-run-code-button pre {
+	z-index: 1;
+}
+
+.load-state-indicator.visible {
+	transform: translateX(0);
+}
+
+.load-state-indicator::before {
+	content: "";
+	box-shadow: -1em 0 1em -0.75em inset var(--background-modifier-box-shadow);
+	position: absolute;
+	display: block;
+	width: 100%;
+	height: 100%;
+	transform: translateX(-2em);
+	opacity: 0;
+	transition: transform 0.25s, opacity 0.25s;
+}
+
+.load-state-indicator.visible::before {
+	transform: translateX(0);
+	opacity: 1;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -114,3 +114,26 @@ input.interactive-stdin {
 	color: var(--text-muted);
 	padding: 0.5em;
 }
+
+.load-state-indicator {
+	position: absolute;
+	top: 0.5em;
+	left: -2em;
+	widtH: 2em;
+	height: 2em;
+	background: var(--background-primary-alt);
+	border-top-left-radius: 4px;
+	border-bottom-left-radius: 4px;
+	box-shadow: -1em 0 1em -0.75em inset var(--background-modifier-box-shadow);
+	color: var(--tx1);
+}
+
+.load-state-indicator svg {
+	width: 1.5em;
+	height: 1.5em;
+	margin: 0.25em;
+}
+
+.has-run-code-button {
+	position: relative;
+}

--- a/src/svgs/loadEllipses.ts
+++ b/src/svgs/loadEllipses.ts
@@ -1,0 +1,9 @@
+import parseHTML from "./parseHTML";
+
+const svg = parseHTML(`<svg width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+        <path d="M1 5 V 5 M 5 5 V 5 M 9 5 V 5" style="fill: none; stroke: currentColor; stroke-width: 0.5"/>
+        </svg>`);
+
+export default () => {
+    return svg.cloneNode(true);
+}

--- a/src/svgs/loadEllipses.ts
+++ b/src/svgs/loadEllipses.ts
@@ -1,10 +1,17 @@
 import parseHTML from "./parseHTML";
 
 const svg = parseHTML(`<svg width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-        <circle cx="1.5" r="1" cy="5" style="fill:currentColor"/>
-        <circle cx="5" r="1" cy="5" style="fill:currentColor"/>
-        <circle cx="8.5" r="1" cy="5" style="fill:currentColor"/>
-        </svg>`);
+    <style>
+        @keyframes load_ellipse_anim{
+	    0%{transform: translateY(0);}
+	    25%{transform: translateY(-1.5px);}
+	    100%{transform: translateY(0);}
+        }
+    </style>
+    <circle cx="1.5" r="1" cy="5" style="fill:currentColor; animation: load_ellipse_anim 1.3s infinite ease-in-out 0.3s;"/>
+    <circle cx="5" r="1" cy="5" style="fill:currentColor; animation: load_ellipse_anim 1.3s infinite ease-in-out 0.6s;"/>
+    <circle cx="8.5" r="1" cy="5" style="fill:currentColor; animation: load_ellipse_anim 1.3s infinite ease-in-out 0.9s;"/>
+</svg>`);
 
 export default () => {
     return svg.cloneNode(true);

--- a/src/svgs/loadEllipses.ts
+++ b/src/svgs/loadEllipses.ts
@@ -1,7 +1,9 @@
 import parseHTML from "./parseHTML";
 
 const svg = parseHTML(`<svg width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-        <path d="M1 5 V 5 M 5 5 V 5 M 9 5 V 5" style="fill: none; stroke: currentColor; stroke-width: 0.5"/>
+        <circle cx="1.5" r="1" cy="5" style="fill:currentColor"/>
+        <circle cx="5" r="1" cy="5" style="fill:currentColor"/>
+        <circle cx="8.5" r="1" cy="5" style="fill:currentColor"/>
         </svg>`);
 
 export default () => {

--- a/src/svgs/loadSpinner.ts
+++ b/src/svgs/loadSpinner.ts
@@ -1,6 +1,10 @@
-export default () => {
-    return `<svg width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+import parseHTML from "./parseHTML";
+
+const svg = parseHTML(`<svg width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
         <style>@keyframes spinner_svv2{100%{transform:rotate(360deg)}}</style>
         <path d="M1 5 A 4 4 0 1 1 9 5" style="transform-origin: center; fill: none; stroke: currentColor; stroke-width: 0.5; animation:spinner_svv2 .75s infinite linear"/>
-        </svg>`;
+        </svg>`);
+
+export default () => {
+    return svg.cloneNode(true);
 }

--- a/src/svgs/loadSpinner.ts
+++ b/src/svgs/loadSpinner.ts
@@ -1,0 +1,6 @@
+export default () => {
+    return `<svg width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+        <style>@keyframes spinner_svv2{100%{transform:rotate(360deg)}}</style>
+        <path d="M1 5 A 4 4 0 1 1 9 5" style="transform-origin: center; fill: none; stroke: currentColor; stroke-width: 0.5; animation:spinner_svv2 .75s infinite linear"/>
+        </svg>`;
+}

--- a/src/svgs/parseHTML.ts
+++ b/src/svgs/parseHTML.ts
@@ -1,0 +1,5 @@
+export default (html: string) => {
+    let container = document.createElement("div");
+    container.innerHTML = html;
+    return container.firstElementChild;
+}


### PR DESCRIPTION
I added an indicator for when blocks are running.

- Shows and hides without any language-specific code
- *Allows* language-specific code for Notebook Mode to indicate queuing
- Slide-out/slide-in animation
- Tooltips
- No indicator when block finishes in <100ms

![running-indicator](https://user-images.githubusercontent.com/26300854/195366912-817879e5-6e65-4bf6-985c-ef9397f0b2e0.gif)
