### PR TITLE
Fix Rust Execution

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -262,7 +262,7 @@ export default class ExecuteCodePlugin extends Plugin {
 				button.className = runButtonDisabledClass;
 
 				const transformedCode = await new CodeInjector(this.app, this.settings, language).injectCode(srcCode);
-				this.runCode(transformedCode, out, button, this.settings.cargoPath, this.settings.cargoArgs, this.settings.rustFileExtension, language, file);
+				this.runCode(transformedCode, out, button, this.settings.cargoPath, "eval", this.settings.rustFileExtension, language, file);
 			});
 
 		} else if (language === "r") {

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,7 +262,7 @@ export default class ExecuteCodePlugin extends Plugin {
 				button.className = runButtonDisabledClass;
 
 				const transformedCode = await new CodeInjector(this.app, this.settings, language).injectCode(srcCode);
-				this.runCode(transformedCode, out, button, this.settings.cargoPath, "eval", this.settings.rustFileExtension, language, file);
+				this.runCode(transformedCode, out, button, this.settings.cargoPath, "eval" + this.settings.cargoEvalArgs, this.settings.rustFileExtension, language, file);
 			});
 
 		} else if (language === "r") {

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -43,7 +43,7 @@ export interface ExecutorSettings {
 	powershellFileExtension: string;
 	powershellInject: string;
 	cargoPath: string;
-	cargoArgs: string;
+	cargoEvalArgs: string;
 	rustInject: string;
 	cppRunner: string;
 	cppInject: string;
@@ -134,7 +134,7 @@ export const DEFAULT_SETTINGS: ExecutorSettings = {
 	powershellFileExtension: "ps1",
 	powershellInject: "",
 	cargoPath: "cargo",
-	cargoArgs: "run",
+	cargoEvalArgs: "",
 	rustInject: "",
 	cppRunner: "cling",
 	cppInject: "",


### PR DESCRIPTION
This fixes the Rust argument code to use `cargo eval` instead of `cargo run`. 

I chose to make a new setting key instead of reusing `cargoArgs` because if people already had v1.0.0 installed, `cargoArgs` would be set to `run` in their data.json. I think that this solution is preferable to having an adapter function to change the property, but I'm open to review on that.

- [x] Tested and verified to work well (Windows 10, mingw64)

This closes #81 
This closes #119 