### PR TITLE
Bug Fixes for Edge Cases in Notebook Mode

### DIFF
--- a/src/ExecutorContainer.ts
+++ b/src/ExecutorContainer.ts
@@ -24,6 +24,12 @@ export default class ExecutorContainer extends EventEmitter implements Iterable<
 	constructor(plugin: ExecuteCodePlugin) {
 		super();
 		this.plugin = plugin;
+		
+		window.addEventListener("beforeunload", async () => {
+			for(const executor of this) {
+				executor.stop();
+			}
+		});
 	}
 
 	/**

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -83,6 +83,8 @@ export default class PythonExecutor extends AsyncExecutor {
 					outputter.write(
 						stringData.substring(0, stringData.length - finishSigil.length)
 					);
+					
+					this.process.removeListener("exit", resolve);
 
 					this.process.stdout.removeListener("data", writeToStdout);
 					this.process.stderr.removeListener("data", writeToStderr);
@@ -91,6 +93,8 @@ export default class PythonExecutor extends AsyncExecutor {
 					outputter.write(stringData);
 				}
 			}
+			
+			this.process.addListener("exit", resolve);
 
 			this.process.stdout.on("data", writeToStdout);
 			this.process.stderr.on("data", writeToStderr);

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -57,6 +57,8 @@ export default class PythonExecutor extends AsyncExecutor {
 		outputter.queueBlock();
 
 		return this.addJobToQueue((resolve, reject) => {
+			if(this.process.exitCode != null) return resolve();
+			
 			const finishSigil = `SIGIL_BLOCK_DONE${Math.random()}_${Date.now()}_${code.length}`;
 
 			const wrappedCode = `
@@ -85,7 +87,7 @@ export default class PythonExecutor extends AsyncExecutor {
 						stringData.substring(0, stringData.length - finishSigil.length)
 					);
 					
-					this.process.removeListener("exit", resolve);
+					this.process.removeListener("close", resolve);
 
 					this.process.stdout.removeListener("data", writeToStdout);
 					this.process.stderr.removeListener("data", writeToStderr);
@@ -95,7 +97,7 @@ export default class PythonExecutor extends AsyncExecutor {
 				}
 			}
 			
-			this.process.addListener("exit", resolve);
+			this.process.addListener("close", resolve);
 
 			this.process.stdout.on("data", writeToStdout);
 			this.process.stderr.on("data", writeToStderr);

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -60,6 +60,8 @@ export default class PythonExecutor extends AsyncExecutor {
 			if(this.process.exitCode !== null) return resolve();
 			
 			const finishSigil = `SIGIL_BLOCK_DONE${Math.random()}_${Date.now()}_${code.length}`;
+			
+			outputter.startBlock();
 
 			const wrappedCode = `
 			try { eval(${JSON.stringify(code)}); } catch(e) { console.error(e); }

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -57,7 +57,7 @@ export default class PythonExecutor extends AsyncExecutor {
 		outputter.queueBlock();
 
 		return this.addJobToQueue((resolve, reject) => {
-			if(this.process.exitCode != null) return resolve();
+			if(this.process.exitCode !== null) return resolve();
 			
 			const finishSigil = `SIGIL_BLOCK_DONE${Math.random()}_${Date.now()}_${code.length}`;
 

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -16,6 +16,8 @@ export default class PythonExecutor extends AsyncExecutor {
 		args.unshift(`-e`, `require("repl").start({prompt: "", preview: false, ignoreUndefined: true}).on("exit", ()=>process.exit())`);
 
 		this.process = spawn(settings.nodePath, args);
+		
+		this.process.on("close", () => this.emit("close"));
 
 		//send a newline so that the intro message won't be buffered
 		this.dismissIntroMessage().then(() => {/* do nothing */});
@@ -31,7 +33,6 @@ export default class PythonExecutor extends AsyncExecutor {
 			this.process.on("close", () => {
 				resolve();
 			});
-			this.emit("close");
 		});
 	}
 

--- a/src/executors/python/PythonExecutor.ts
+++ b/src/executors/python/PythonExecutor.ts
@@ -24,6 +24,8 @@ export default class PythonExecutor extends AsyncExecutor {
 		args.unshift("-i");
 
 		this.process = spawn(settings.pythonPath, args);
+		
+		this.process.on("close", () => this.emit("close"));
 
 		this.printFunctionName = `__print_${Math.random().toString().substring(2)}_${Date.now()}`;
 		this.localsDictionaryName = `__locals_${Math.random().toString().substring(2)}_${Date.now()}`;
@@ -43,7 +45,6 @@ export default class PythonExecutor extends AsyncExecutor {
 			this.process.on("close", () => {
 				resolve();
 			});
-			this.emit("close");
 		});
 	}
 

--- a/src/executors/python/PythonExecutor.ts
+++ b/src/executors/python/PythonExecutor.ts
@@ -93,6 +93,8 @@ ${this.globalsDictionaryName} = {**globals()}
 		
 		// TODO: Is handling for reject necessary?
 		return this.addJobToQueue((resolve, reject) => {
+			if (this.process.exitCode != null) return resolve();
+			
 			const finishSigil = `SIGIL_BLOCK_DONE${Math.random()}_${Date.now()}_${code.length}`;
 			
 			outputter.startBlock();
@@ -122,7 +124,7 @@ ${this.globalsDictionaryName} = {**globals()}
 
 					this.process.stdout.removeListener("data", writeToStdout)
 					this.process.stderr.removeListener("data", writeToStderr);
-					this.process.removeListener("exit", resolve);
+					this.process.removeListener("close", resolve);
 					outputter.write(str);
 
 					resolve();
@@ -137,7 +139,7 @@ ${this.globalsDictionaryName} = {**globals()}
 				outputter.writeErr(removedPrompts);
 			}
 			
-			this.process.on("exit", resolve);
+			this.process.on("close", resolve);
 
 			this.process.stdout.on("data", writeToStdout);
 			this.process.stderr.on("data", writeToStderr);

--- a/src/executors/python/PythonExecutor.ts
+++ b/src/executors/python/PythonExecutor.ts
@@ -121,6 +121,7 @@ ${this.globalsDictionaryName} = {**globals()}
 
 					this.process.stdout.removeListener("data", writeToStdout)
 					this.process.stderr.removeListener("data", writeToStderr);
+					this.process.removeListener("exit", resolve);
 					outputter.write(str);
 
 					resolve();
@@ -134,6 +135,8 @@ ${this.globalsDictionaryName} = {**globals()}
 
 				outputter.writeErr(removedPrompts);
 			}
+			
+			this.process.on("exit", resolve);
 
 			this.process.stdout.on("data", writeToStdout);
 			this.process.stderr.on("data", writeToStderr);

--- a/src/executors/python/PythonExecutor.ts
+++ b/src/executors/python/PythonExecutor.ts
@@ -93,7 +93,7 @@ ${this.globalsDictionaryName} = {**globals()}
 		
 		// TODO: Is handling for reject necessary?
 		return this.addJobToQueue((resolve, reject) => {
-			if (this.process.exitCode != null) return resolve();
+			if (this.process.exitCode !== null) return resolve();
 			
 			const finishSigil = `SIGIL_BLOCK_DONE${Math.random()}_${Date.now()}_${code.length}`;
 			


### PR DESCRIPTION
This PR addresses #112 and #115. 

If the user attempts to refresh Obsidian without saving (whether through CTRL + R in the dev tools or through the "Reload app without saving" command), notebook mode executors are now properly closed. Their REPL processes are no longer allowed to stay alive when the plugin doesn't have a reference for them.

If the user uses `process.exit()` (JS) or `exit()` (python), the executor now recognizes that its REPL has stopped, and will close itself. This is reflected in the runtime list, as well as in each block. Blocks that are queued will immediately stop, without trying to run their code.