### PR TITLE
Ensure that settings dropdown always matches open tab

### DIFF
--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -86,6 +86,7 @@ export class SettingsTab extends PluginSettingTab {
 			.addOptions(Object.fromEntries(
 				canonicalLanguages.map(lang => [lang, DISPLAY_NAMES[lang]])
 			))
+			.setValue(this.plugin.settings.lastOpenLanguageTab || canonicalLanguages[0])
 			.onChange(async (value: LanguageId)=> {
 				this.focusContainer(value);
 				this.plugin.settings.lastOpenLanguageTab = value;


### PR DESCRIPTION
A tiny 1-line PR to fix #122. Makes sure that the settings dropdown's selected option always matches the open language tab.

This closes #122 