### PR TITLE
Add 'py' as an alias for 'python'

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import ExecutorManagerView, {
 
 import runAllCodeBlocks from './runAllCodeBlocks';
 
-export const languageAliases = ["javascript", "typescript", "bash", "csharp", "wolfram", "nb", "wl", "hs"] as const;
+export const languageAliases = ["javascript", "typescript", "bash", "csharp", "wolfram", "nb", "wl", "hs", "py"] as const;
 export const canonicalLanguages = ["js", "ts", "cs", "lua", "python", "cpp",
 	"prolog", "shell", "groovy", "r", "go", "rust", "java", "powershell", "kotlin", "mathematica", "haskell"] as const;
 export const supportedLanguages = [...languageAliases, ...canonicalLanguages] as const;

--- a/src/transforms/TransformCode.ts
+++ b/src/transforms/TransformCode.ts
@@ -12,18 +12,19 @@ import type {LanguageId} from "src/main";
  */
 export function getLanguageAlias(language: string | undefined): LanguageId | undefined {
 	if (language === undefined) return undefined;
-	const replaced = language
-		.replace("javascript", "js")
-		.replace("typescript", "ts")
-		.replace("csharp", "cs")
-		.replace("bash", "shell")
-		.replace(/py$/, "python")
-		.replace("wolfram", "mathematica")
-		.replace("nb", "mathematica")
-		.replace("wl", "mathematica")
-		.replace("hs", "haskell") as LanguageId;
-	if (canonicalLanguages.includes(replaced))
-		return replaced;
+	switch(language) {
+		case "javascript": return "js";
+		case "typescript": return "ts";
+		case "csharp": return "cs";
+		case "bash": return "shell";
+		case "py": return "python";
+		case "wolfram": return "mathematica";
+		case "nb": return "mathematica";
+		case "wl": "mathematica";
+		case "hs": return "haskell";
+	}
+	if ((canonicalLanguages as readonly string[]).includes(language))
+		return language as LanguageId;
 	return undefined;
 }
 

--- a/src/transforms/TransformCode.ts
+++ b/src/transforms/TransformCode.ts
@@ -17,6 +17,7 @@ export function getLanguageAlias(language: string | undefined): LanguageId | und
 		.replace("typescript", "ts")
 		.replace("csharp", "cs")
 		.replace("bash", "shell")
+		.replace("py", "python")
 		.replace("wolfram", "mathematica")
 		.replace("nb", "mathematica")
 		.replace("wl", "mathematica")

--- a/src/transforms/TransformCode.ts
+++ b/src/transforms/TransformCode.ts
@@ -17,7 +17,7 @@ export function getLanguageAlias(language: string | undefined): LanguageId | und
 		.replace("typescript", "ts")
 		.replace("csharp", "cs")
 		.replace("bash", "shell")
-		.replace("py", "python")
+		.replace(/py$/, "python")
 		.replace("wolfram", "mathematica")
 		.replace("nb", "mathematica")
 		.replace("wl", "mathematica")


### PR DESCRIPTION
A tiny QOL PR to add 'py' as a valid language alias for Python