### PR TITLE
Make queued running indicators hide after runtime death

### DIFF
--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -35,10 +35,11 @@ export default class PythonExecutor extends AsyncExecutor {
 	 */
 	stop(): Promise<void> {
 		return new Promise((resolve, reject) => {
-			this.process.kill();
 			this.process.on("close", () => {
 				resolve();
 			});
+			this.process.kill();
+			this.process = null;
 		});
 	}
 
@@ -63,7 +64,7 @@ export default class PythonExecutor extends AsyncExecutor {
 		outputter.queueBlock();
 
 		return this.addJobToQueue((resolve, reject) => {
-			if(this.process.exitCode !== null) return resolve();
+			if(this.process === null) return resolve();
 			
 			const finishSigil = `SIGIL_BLOCK_DONE${Math.random()}_${Date.now()}_${code.length}`;
 			

--- a/src/executors/python/PythonExecutor.ts
+++ b/src/executors/python/PythonExecutor.ts
@@ -46,10 +46,11 @@ export default class PythonExecutor extends AsyncExecutor {
 	 */
 	stop(): Promise<void> {
 		return new Promise((resolve, reject) => {
-			this.process.kill();
 			this.process.on("close", () => {
 				resolve();
 			});
+			this.process.kill();
+			this.process = null;
 		});
 	}
 
@@ -98,7 +99,7 @@ ${this.globalsDictionaryName} = {**globals()}
 		
 		// TODO: Is handling for reject necessary?
 		return this.addJobToQueue((resolve, reject) => {
-			if (this.process.exitCode !== null) return resolve();
+			if (this.process === null) return resolve();
 			
 			const finishSigil = `SIGIL_BLOCK_DONE${Math.random()}_${Date.now()}_${code.length}`;
 			


### PR DESCRIPTION
This PR fixes #138 by measuring if the **process** is null instead of only checking the exit code. 

Before, there was a condition where the process could be `kill()`d, but not completely closed yet, and therefore not have an exit code. This fixes that.