### PR TITLE
WSL support

### DIFF
--- a/src/ExecutorContainer.ts
+++ b/src/ExecutorContainer.ts
@@ -95,6 +95,6 @@ export default class ExecutorContainer extends EventEmitter implements Iterable<
 		else if (language in nonInteractiveExecutors)
 			return new nonInteractiveExecutors[language](this.plugin.settings, file);
 		// Generic non-interactive language executor
-		return new NonInteractiveCodeExecutor(needsShell, file, language);
+		return new NonInteractiveCodeExecutor(this.plugin.settings, needsShell, file, language);
 	}
 }

--- a/src/executors/CppExecutor.ts
+++ b/src/executors/CppExecutor.ts
@@ -5,11 +5,9 @@ import type {Outputter} from "src/Outputter";
 import type {ExecutorSettings} from "src/settings/Settings";
 
 export default class CppExecutor extends NonInteractiveCodeExecutor {
-	settings: ExecutorSettings
 
 	constructor(settings: ExecutorSettings, file: string) {
-		super(false, file, "cpp");
-		this.settings = settings;
+		super(settings, false, file, "cpp");
 	}
 
 	override run(codeBlockContent: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string) {

--- a/src/executors/NonInteractiveCodeExecutor.ts
+++ b/src/executors/NonInteractiveCodeExecutor.ts
@@ -7,6 +7,7 @@ import {LanguageId} from "src/main";
 import { ExecutorSettings } from "../settings/Settings.js";
 import { sep } from "path";
 import { join } from "path/posix";
+import windowsPathToWsl from "../transforms/windowsPathToWsl.js";
 
 export default class NonInteractiveCodeExecutor extends Executor {
 	usesShell: boolean
@@ -41,12 +42,7 @@ export default class NonInteractiveCodeExecutor extends Executor {
 				if (this.settings.wslMode) {
 					args.unshift("-e", cmd);
 					cmd = "wsl";
-					
-					const driveLetter = tempFileName[0].toLowerCase();
-					const posixyPath = tempFileName.replace(/^[^:]*:/, "") //remove drive letter
-						.split(sep).join("/"); //force / as separator
-						
-					args.push(join("/mnt/", driveLetter, posixyPath));
+					args.push(windowsPathToWsl(tempFileName));
 				} else {
 					args.push(tempFileName);	
 				}

--- a/src/executors/NonInteractiveCodeExecutor.ts
+++ b/src/executors/NonInteractiveCodeExecutor.ts
@@ -4,16 +4,19 @@ import * as child_process from "child_process";
 import Executor from "./Executor";
 import {Outputter} from "src/Outputter";
 import {LanguageId} from "src/main";
+import { ExecutorSettings } from "../settings/Settings.js";
 
 export default class NonInteractiveCodeExecutor extends Executor {
 	usesShell: boolean
 	stdoutCb: (chunk: any) => void
 	stderrCb: (chunk: any) => void
 	resolveRun: (value: void | PromiseLike<void>) => void | undefined = undefined;
+	settings: ExecutorSettings;
 
-	constructor(usesShell: boolean, file: string, language: LanguageId) {
+	constructor(settings: ExecutorSettings, usesShell: boolean, file: string, language: LanguageId) {
 		super(file, language);
 
+		this.settings = settings;
 		this.usesShell = usesShell;
 	}
 

--- a/src/executors/ReplExecutor.ts
+++ b/src/executors/ReplExecutor.ts
@@ -17,6 +17,11 @@ export default abstract class ReplExecutor extends AsyncExecutor {
         
         this.settings = settings;
         
+        if (this.settings.wslMode) {
+            args.unshift("-e", path, "--");
+            path = "wsl";
+        }
+        
         this.process = spawn(path, args);
         
         this.process.on("close", () => {

--- a/src/executors/ReplExecutor.ts
+++ b/src/executors/ReplExecutor.ts
@@ -18,7 +18,7 @@ export default abstract class ReplExecutor extends AsyncExecutor {
         this.settings = settings;
         
         if (this.settings.wslMode) {
-            args.unshift("-e", path, "--");
+            args.unshift("-e", path);
             path = "wsl";
         }
         

--- a/src/executors/ReplExecutor.ts
+++ b/src/executors/ReplExecutor.ts
@@ -1,4 +1,5 @@
 import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+import { Notice } from "obsidian";
 import { LanguageId } from "../main.js";
 import { Outputter } from "../Outputter.js";
 import { ExecutorSettings } from "../settings/Settings.js";
@@ -26,6 +27,7 @@ export default abstract class ReplExecutor extends AsyncExecutor {
         
         this.process.on("close", () => {
             this.emit("close");
+            new Notice("Runtime exited");
             this.process = null;
         });
         

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -8,6 +8,7 @@ export interface ExecutorSettings {
 	
 	timeout: number;
 	allowInput: boolean;
+	wslMode: boolean;
 	nodePath: string;
 	nodeArgs: string;
 	jsInject: string;
@@ -108,6 +109,7 @@ export const DEFAULT_SETTINGS: ExecutorSettings = {
 	
 	timeout: 10000,
 	allowInput: true,
+	wslMode: false,
 	nodePath: "node",
 	nodeArgs: "",
 	jsInject: "",

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -75,16 +75,19 @@ export class SettingsTab extends PluginSettingTab {
 					this.plugin.settings.allowInput = value
 					await this.plugin.saveSettings();
 				}));
-		new Setting(containerEl)
-			.setName('WSL Mode')
-			.setDesc("Whether or not to run code in the Windows Subsystem for Linux. If you don't have WSL installed, don't turn this on!")
-			.addToggle(text => text
-				.setValue(this.plugin.settings.wslMode)
-				.onChange(async (value) => {
-					console.log('WSL Mode set to: ' + value);
-					this.plugin.settings.wslMode = value
-					await this.plugin.saveSettings();
-				}));
+		
+		if(process.platform === "win32") {
+			new Setting(containerEl)
+				.setName('WSL Mode')
+				.setDesc("Whether or not to run code in the Windows Subsystem for Linux. If you don't have WSL installed, don't turn this on!")
+				.addToggle(text => text
+					.setValue(this.plugin.settings.wslMode)
+					.onChange(async (value) => {
+						console.log('WSL Mode set to: ' + value);
+						this.plugin.settings.wslMode = value
+						await this.plugin.saveSettings();
+					}));
+		}
 
 		// TODO setting per language that requires main function if main function should be implicitly made or not, if not, non-main blocks will not have a run button
 

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -75,6 +75,16 @@ export class SettingsTab extends PluginSettingTab {
 					this.plugin.settings.allowInput = value
 					await this.plugin.saveSettings();
 				}));
+		new Setting(containerEl)
+			.setName('WSL Mode')
+			.setDesc("Whether or not to run code in the Windows Subsystem for Linux. If you don't have WSL installed, don't turn this on!")
+			.addToggle(text => text
+				.setValue(this.plugin.settings.wslMode)
+				.onChange(async (value) => {
+					console.log('WSL Mode set to: ' + value);
+					this.plugin.settings.wslMode = value
+					await this.plugin.saveSettings();
+				}));
 
 		// TODO setting per language that requires main function if main function should be implicitly made or not, if not, non-main blocks will not have a run button
 

--- a/src/transforms/windowsPathToWsl.ts
+++ b/src/transforms/windowsPathToWsl.ts
@@ -1,4 +1,5 @@
-import { join, sep } from "path";
+import { join } from "path/posix";
+import { sep } from "path";
 
 export default (windowsPath: string) => {
     const driveLetter = windowsPath[0].toLowerCase();

--- a/src/transforms/windowsPathToWsl.ts
+++ b/src/transforms/windowsPathToWsl.ts
@@ -1,0 +1,9 @@
+import { join, sep } from "path";
+
+export default (windowsPath: string) => {
+    const driveLetter = windowsPath[0].toLowerCase();
+    const posixyPath = windowsPath.replace(/^[^:]*:/, "") //remove drive letter
+        .split(sep).join("/"); //force / as separator
+        
+    return join("/mnt/", driveLetter, posixyPath);
+}


### PR DESCRIPTION
This PR fixes #133 by adding a new setting: WSL mode. When WSL mode is on, it runs all commands in WSL via `wsl -e <command> <args...>`. On non-Windows installations, the WSL setting will not appear.

TODO:
- [x] Test on non-clean-install WSL
- [x] Is this the most ergonomic option? Would users prefer to have a per-language toggle?
- [x] Implement in non-basic executors (waiting on #140)