### PR TITLE
Improve styles

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -198,11 +198,10 @@ input.interactive-stdin {
 	content: "";
 	box-shadow: -1em 0 1em -0.75em inset var(--background-modifier-box-shadow);
 	position: absolute;
-	left: -2em;
 	display: block;
 	width: 100%;
 	height: 100%;
-	transform: translateX(-2em);
+	transform: translateX(2em);
 	opacity: 0;
 	transition: transform 0.25s, opacity 0.25s;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -71,7 +71,7 @@ pre:hover .run-button-disabled, pre:hover .clear-button-disabled {
 }
 
 pre:hover code.language-output {
-	margin-bottom: 23px;
+	margin-bottom: 28px;
 }
 
 :not(.use-custom-output-color) code.language-output span.stdout {

--- a/src/styles.css
+++ b/src/styles.css
@@ -198,6 +198,7 @@ input.interactive-stdin {
 	content: "";
 	box-shadow: -1em 0 1em -0.75em inset var(--background-modifier-box-shadow);
 	position: absolute;
+	left: -2em;
 	display: block;
 	width: 100%;
 	height: 100%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -161,9 +161,17 @@ input.interactive-stdin {
 	padding: 0.5em;
 }
 
+.has-run-code-button {
+	position: relative;
+}
+
+.has-run-code-button pre {
+	z-index: 1;
+}
+
 .load-state-indicator {
 	position: absolute;
-	top: 0.5em;
+	top: 0.1em;
 	left: -2em;
 	widtH: 2em;
 	height: 2em;
@@ -179,14 +187,6 @@ input.interactive-stdin {
 	width: 1.5em;
 	height: 1.5em;
 	margin: 0.25em;
-}
-
-.has-run-code-button {
-	position: relative;
-}
-
-.has-run-code-button pre {
-	z-index: 1;
 }
 
 .load-state-indicator.visible {

--- a/src/styles.css
+++ b/src/styles.css
@@ -181,6 +181,7 @@ input.interactive-stdin {
 	color: var(--tx1);
 	transform: translateX(2em);
 	transition: transform 0.25s;
+	cursor: pointer;
 }
 
 .load-state-indicator svg {


### PR DESCRIPTION
Just some small css tweaks:

1. Fix the load state indicator on short code blocks poking out the bottom:

Before:

![image](https://user-images.githubusercontent.com/56327606/196950440-7a520b27-d258-470b-a4c7-26a28f096bba.png)

![image](https://user-images.githubusercontent.com/56327606/196950540-871d7928-be4b-4f52-94a2-60581c9599b2.png)

After:

![image](https://user-images.githubusercontent.com/56327606/196950486-7309fc22-fbcf-4906-b790-1874da13bf4a.png)

![image](https://user-images.githubusercontent.com/56327606/196950601-d22d61fb-b9b3-4ea0-adb9-7d954a970aa5.png)

This changes the positioning for all heights of code blocks, but I think it still looks good:

![image](https://user-images.githubusercontent.com/56327606/196952014-7dcb13ad-10aa-40fa-ae6c-47164a37b2d5.png)

2. Fix the load state indicator hoverable when hidden (before):

![image](https://user-images.githubusercontent.com/56327606/196950640-21037966-1d70-4c52-9904-0e2ba50f66c4.png)


4. Make the load state indicator show a pointer cursor on hover

5. Increase spacing between clear / run buttons and code block output:

Before (default theme):

![image](https://user-images.githubusercontent.com/56327606/196950686-47a23899-c85c-4996-bf36-ac7a4a42bc5c.png)

After (default theme):

![image](https://user-images.githubusercontent.com/56327606/196950704-dadd2292-5352-4438-a3e0-3374945f8e30.png)


