### PR TITLE
[Bug Fix] Error Notif on Success

### DIFF
--- a/src/executors/NonInteractiveCodeExecutor.ts
+++ b/src/executors/NonInteractiveCodeExecutor.ts
@@ -83,7 +83,7 @@ export default class NonInteractiveCodeExecutor extends Executor {
 		});
 
 		child.on('close', (code) => {
-			if (code === 0)
+			if (code !== 0)
 				new Notice("Error!");
 
 			// Resolve the run promise once finished running the code block


### PR DESCRIPTION
This PR fixes a bug where the `NonInteractiveCodeExecutor` shows an "Error!" notif when the program *succeeds*. 

The root cause of this is a typo where, instead of checking if the exit code *isn't* 0 (which would indicate failure), it checks if the exit code *is* zero. 

![image](https://user-images.githubusercontent.com/26300854/196959248-114e56fc-00e2-46fd-994d-4ebbb2ebe662.png)
