### PR TITLE
[Bug Fix] Fix Python executor's usage of `exec`/`eval`

### DIFF
--- a/src/executors/python/PythonExecutor.ts
+++ b/src/executors/python/PythonExecutor.ts
@@ -60,6 +60,7 @@ export default class PythonExecutor extends ReplExecutor {
 		this.addJobToQueue((resolve, reject) => {
 			this.process.stdin.write(
 /*python*/`
+${this.globalsDictionaryName} = {**globals()}
 ${this.settings.pythonEmbedPlots ?
 /*python*/`
 try:
@@ -72,7 +73,6 @@ except:
 from __future__ import print_function
 import sys
 ${this.printFunctionName} = print
-${this.globalsDictionaryName} = {**globals()}
 `.replace(/\r\n/g, "\n"));
 
 			this.process.stderr.once("data", (data) => {

--- a/src/executors/python/PythonExecutor.ts
+++ b/src/executors/python/PythonExecutor.ts
@@ -14,7 +14,7 @@ export default class PythonExecutor extends ReplExecutor {
 		}
 	}
 	wrapCode(code: string, finishSigil: string): string {
-		return wrapPython(code, this.globalsDictionaryName, this.localsDictionaryName, this.printFunctionName, 
+		return wrapPython(code, this.globalsDictionaryName, this.printFunctionName, 
 			finishSigil, this.settings.pythonEmbedPlots);
 	}
 
@@ -23,7 +23,6 @@ export default class PythonExecutor extends ReplExecutor {
 	process: ChildProcessWithoutNullStreams
 
 	printFunctionName: string;
-	localsDictionaryName: string;
 	globalsDictionaryName: string;
 
 	constructor(settings: ExecutorSettings, file: string) {
@@ -36,7 +35,6 @@ export default class PythonExecutor extends ReplExecutor {
 			file, "python");
 			
 		this.printFunctionName = `__print_${Math.random().toString().substring(2)}_${Date.now()}`;
-		this.localsDictionaryName = `__locals_${Math.random().toString().substring(2)}_${Date.now()}`;
 		this.globalsDictionaryName = `__globals_${Math.random().toString().substring(2)}_${Date.now()}`;
 	}
 
@@ -74,8 +72,6 @@ except:
 from __future__ import print_function
 import sys
 ${this.printFunctionName} = print
-
-${this.localsDictionaryName} = {}
 ${this.globalsDictionaryName} = {**globals()}
 `.replace(/\r\n/g, "\n"));
 

--- a/src/executors/python/wrapPython.ts
+++ b/src/executors/python/wrapPython.ts
@@ -1,6 +1,6 @@
 export const PLT_DEFAULT_BACKEND_PY_VAR = "OBSIDIAN_EXECUTE_CODE_MATPLOTLIB_DEFAULT_BACKEND";
 
-export default (code: string, globalsName: string, localsName: string, printName: string, finishSigil: string, embedPlots: boolean) =>
+export default (code: string, globalsName: string, printName: string, finishSigil: string, embedPlots: boolean) =>
 /*python*/`
 ${embedPlots ?
 // Use 'agg' raster non-interactive renderer to prevent freezing the runtime on plt.show()
@@ -22,12 +22,12 @@ try:
     try:
         ${printName}(eval(
             compile(${JSON.stringify(code.replace(/\r\n/g, "\n") + "\n")}, "<code block>", "eval"),
-            ${globalsName}, ${localsName}
+            ${globalsName}
         ))
     except SyntaxError:
         exec(
             compile(${JSON.stringify(code.replace(/\r\n/g, "\n") + "\n")}, "<code block>", "exec"),
-            ${globalsName}, ${localsName}
+            ${globalsName}
         )
 except Exception as e:
     ${printName} (e, file=sys.stderr)


### PR DESCRIPTION
Before, the Python executor executed code blocks with two seperate objects for `globals` and `locals`. As per [the python documentation](), "... at the module level, globals and locals are the same dictionary. **If exec gets two separate objects as globals and locals, the code will be executed as if it were embedded in a class definition.**", which caused #146 

This PR fixes the issue by using the two-argument form of `exec` instead of the three-argument form. 

It also creates the globals dict *before* all other initialization code: this means that code blocks will not see any effects from our code. Code blocks calling `globals()` will not show the print function and other executor variables.