### PR TITLE
R Notebook Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ undefined
 3
 ```
 
-To manage the open runtimes for Notebook Mode, you can use the `Open Code Runtime Management` command in the command palette. From this sidebar window, you can stop kernels.
+To manage the open runtimes for Notebook Mode, you can use the `Open Code Runtime Management` command in the command palette. From this sidebar window, you can stop kernels. **Note: force-stopping requires `taskkill` on Windows and `pkill` on Unix. 99% of systems should have these preinstalled: if yours doesn't, please [file an issue](https://github.com/twibiral/obsidian-execute-code/issues/new/choose)**
 
 
 ## Style Settings

--- a/src/ExecutorContainer.ts
+++ b/src/ExecutorContainer.ts
@@ -6,10 +6,12 @@ import PrologExecutor from "./executors/PrologExecutor";
 import PythonExecutor from "./executors/python/PythonExecutor";
 import CppExecutor from './executors/CppExecutor';
 import ExecuteCodePlugin, {LanguageId} from "./main";
+import RExecutor from "./executors/RExecutor.js";
 
 const interactiveExecutors: Partial<Record<LanguageId, any>> = {
 	"js": NodeJSExecutor,
-	"python": PythonExecutor
+	"python": PythonExecutor,
+	"r": RExecutor
 };
 
 const nonInteractiveExecutors: Partial<Record<LanguageId, any>> = {

--- a/src/executors/NodeJSExecutor.ts
+++ b/src/executors/NodeJSExecutor.ts
@@ -18,20 +18,6 @@ export default class NodeJSExecutor extends ReplExecutor {
 	}
 
 	/**
-	 * Close the runtime.
-	 * @returns A promise that resolves once the runtime is fully closed
-	 */
-	stop(): Promise<void> {
-		return new Promise((resolve, reject) => {
-			this.process.on("close", () => {
-				resolve();
-			});
-			this.process.kill();
-			this.process = null;
-		});
-	}
-
-	/**
 	 * Writes a single newline to ensure that the stdin is set up correctly.
 	 */
 	async setup() {

--- a/src/executors/RExecutor.ts
+++ b/src/executors/RExecutor.ts
@@ -15,19 +15,15 @@ export default class RExecutor extends ReplExecutor {
 		
 		let conArgName = `notebook_connection_${Math.random().toString(16).substring(2)}`;
 
-		args.unshift(`-e`, `${conArgName}=file("stdin", "r"); while(1) { eval(parse(text= tail(readLines(con = ${conArgName}, n=1)))) }`)
+		// This is the R repl. 
+		// It's coded by itself because Rscript has no REPL, and adding an additional dep on R would be lazy.
+		//It doesn't handle printing by itself because of the need to print the sigil, so
+		//   it's really more of a REL.
+		args.unshift(`-e`, 
+			/*R*/
+			`${conArgName}=file("stdin", "r"); while(1) { eval(parse(text=tail(readLines(con = ${conArgName}, n=1)))) }`
+		)
 		
-		/*`			
-				try({ 
-					print(
-						eval(
-							parse(
-								text = readLines(n=4)
-							)
-						)
-					)
-				})
-		`.replace(/[\r\n\s]+/g, ""));*/
 
 		super(settings, settings.RPath, args, file, "r");
 	}

--- a/src/executors/RExecutor.ts
+++ b/src/executors/RExecutor.ts
@@ -1,0 +1,61 @@
+import {ChildProcessWithoutNullStreams, spawn} from "child_process";
+import {Outputter} from "src/Outputter";
+import {ExecutorSettings} from "src/settings/Settings";
+import AsyncExecutor from "./AsyncExecutor";
+import ReplExecutor from "./ReplExecutor.js";
+
+
+export default class RExecutor extends ReplExecutor {
+
+	process: ChildProcessWithoutNullStreams
+
+	constructor(settings: ExecutorSettings, file: string) {
+		//use empty array for empty string, instead of [""]
+		const args = settings.RArgs ? settings.RArgs.split(" ") : [];
+		
+		let conArgName = `notebook_connection_${Math.random().toString(16).substring(2)}`;
+
+		args.unshift(`-e`, `${conArgName} <- file("stdin"); while(1) { eval(parse(text = readLines(${conArgName}, n=1))) }`);
+
+		super(settings, settings.nodePath, args, file, "r");
+	}
+
+	/**
+	 * Close the runtime.
+	 * @returns A promise that resolves once the runtime is fully closed
+	 */
+	stop(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			this.process.on("close", () => {
+				resolve();
+			});
+			this.process.kill();
+			this.process = null;
+		});
+	}
+
+	/**
+	 * Writes a single newline to ensure that the stdin is set up correctly.
+	 */
+	async setup() {
+		this.process.stdin.write("\n");
+	}
+	
+	wrapCode(code: string, finishSigil: string): string {
+		return `tryCatch({
+			cat(sprintf("%s", ${code}))
+		},
+		error = function(e){
+			cat(sprintf("%s", e), file=stderr())
+		}, 
+		finally = {
+			cat(${JSON.stringify(finishSigil)})
+		})` +
+			"\n";
+	}
+	
+	removePrompts(output: string, source: "stdout" | "stderr"): string {
+		return output;
+	}
+
+}

--- a/src/executors/RExecutor.ts
+++ b/src/executors/RExecutor.ts
@@ -13,9 +13,9 @@ export default class RExecutor extends ReplExecutor {
 		//use empty array for empty string, instead of [""]
 		const args = settings.RArgs ? settings.RArgs.split(" ") : [];
 		
-		let conArgName = `notebook_connection` //_${Math.random().toString(16).substring(2)}`;
+		let conArgName = `notebook_connection_${Math.random().toString(16).substring(2)}`;
 
-		args.unshift(`-e`, `con=file("stdin", "r"); while(1) { eval(parse(text= tail(readLines(con = con, n=1)))) }`)
+		args.unshift(`-e`, `${conArgName}=file("stdin", "r"); while(1) { eval(parse(text= tail(readLines(con = ${conArgName}, n=1)))) }`)
 		
 		/*`			
 				try({ 

--- a/src/executors/RExecutor.ts
+++ b/src/executors/RExecutor.ts
@@ -15,7 +15,7 @@ export default class RExecutor extends ReplExecutor {
 		
 		let conArgName = `notebook_connection` //_${Math.random().toString(16).substring(2)}`;
 
-		args.unshift(`-e`, `con=file("stdin", "r"); while(1) {}; eval(parse(text= tail(readLines(con = con, n=1))))`)
+		args.unshift(`-e`, `con=file("stdin", "r"); while(1) { eval(parse(text= tail(readLines(con = con, n=1)))) }`)
 		
 		/*`			
 				try({ 

--- a/src/executors/ReplExecutor.ts
+++ b/src/executors/ReplExecutor.ts
@@ -94,12 +94,12 @@ export default abstract class ReplExecutor extends AsyncExecutor {
     }
     
     stop(): Promise<void> {
-        return new Promise(async (resolve, reject) => {
+        return new Promise((resolve, reject) => {
             this.process.on("close", () => {
                 resolve();
             });            
             
-            await killWithChildren(this.process.pid);
+            killWithChildren(this.process.pid);
             this.process = null;
         });
     }

--- a/src/executors/ReplExecutor.ts
+++ b/src/executors/ReplExecutor.ts
@@ -3,6 +3,7 @@ import { LanguageId } from "../main.js";
 import { Outputter } from "../Outputter.js";
 import { ExecutorSettings } from "../settings/Settings.js";
 import AsyncExecutor from "./AsyncExecutor.js";
+import killWithChildren from "./killWithChildren.js";
 
 export default abstract class ReplExecutor extends AsyncExecutor {
     process: ChildProcessWithoutNullStreams;
@@ -93,11 +94,12 @@ export default abstract class ReplExecutor extends AsyncExecutor {
     }
     
     stop(): Promise<void> {
-        return new Promise((resolve, reject) => {
+        return new Promise(async (resolve, reject) => {
             this.process.on("close", () => {
                 resolve();
-            });
-            this.process.kill();
+            });            
+            
+            await killWithChildren(this.process.pid);
             this.process = null;
         });
     }

--- a/src/executors/killWithChildren.ts
+++ b/src/executors/killWithChildren.ts
@@ -1,15 +1,10 @@
-import { exec } from "child_process"
+import { execSync } from "child_process"
 
-export default (pid: number): Promise<void> => {
-    
-    return new Promise((resolve, reject) => {
-        if(process.platform === "win32") {
-            exec(`taskkill /pid ${pid} /T /F`, () => resolve());
-        } else {
-            exec(`pkill -P ${pid}`, () => {
-                process.kill(pid);
-                resolve();
-            });
-        }
-    });
+export default (pid: number) => {
+    if(process.platform === "win32") {
+        execSync(`taskkill /pid ${pid} /T /F`)
+    } else {
+        execSync(`pkill -P ${pid}`)
+        process.kill(pid);
+    }
 }

--- a/src/executors/killWithChildren.ts
+++ b/src/executors/killWithChildren.ts
@@ -1,0 +1,15 @@
+import { exec } from "child_process"
+
+export default (pid: number): Promise<void> => {
+    
+    return new Promise((resolve, reject) => {
+        if(process.platform === "win32") {
+            exec(`taskkill /pid ${pid} /T /F`, () => resolve());
+        } else {
+            exec(`pkill -P ${pid}`, () => {
+                process.kill(pid);
+                resolve();
+            });
+        }
+    });
+}

--- a/src/executors/python/PythonExecutor.ts
+++ b/src/executors/python/PythonExecutor.ts
@@ -40,19 +40,6 @@ export default class PythonExecutor extends ReplExecutor {
 		this.globalsDictionaryName = `__globals_${Math.random().toString().substring(2)}_${Date.now()}`;
 	}
 
-	/**
-	 * Close the runtime.
-	 * @returns A promise that resolves once the runtime is fully closed
-	 */
-	stop(): Promise<void> {
-		return new Promise((resolve, reject) => {
-			this.process.on("close", () => {
-				resolve();
-			});
-			this.process.kill();
-			this.process = null;
-		});
-	}
 
 	/**
 	 * Swallows and does not output the "Welcome to Python v..." message that shows at startup.

--- a/src/settings/per-lang/makeRSettings.ts
+++ b/src/settings/per-lang/makeRSettings.ts
@@ -32,5 +32,13 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 console.log('R args set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
+    new Setting(containerEl)
+        .setName("Run R blocks in Notebook Mode")
+        .addToggle((toggle) => toggle
+            .setValue(tab.plugin.settings.rInteractive)
+            .onChange(async (value) => {
+                tab.plugin.settings.rInteractive = value;
+                await tab.plugin.saveSettings();
+            }));
     tab.makeInjectSetting(containerEl, "r");
 }


### PR DESCRIPTION
This PR adds Notebook Mode for the R language. 

This was pretty simple at first, but I found an issue which we may need to follow more closely; when an executor process is closed, any child processes that *it* may have spawned are kept open. This both leaves zombies around and keeps the plugin from recognizing that the executor is closed. There doesn't seem to be any Node API to fix this, so I shelled out to `taskkill` in Windows and `pkill` in unix systems-- someone on Mac should test before this gets merged.

This finishes what was started by #132 

*This PR is a copy-paste of #155, which wasn't registering updates to my branch*