### PR TITLE
Always hide running indicator

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -181,6 +181,8 @@ input.interactive-stdin {
 	color: var(--tx1);
 	transform: translateX(2em);
 	transition: transform 0.25s;
+	opacity: 0;
+	pointer-events: none;
 	cursor: pointer;
 }
 
@@ -192,6 +194,8 @@ input.interactive-stdin {
 
 .load-state-indicator.visible {
 	transform: translateX(0);
+	opacity: 1;
+	pointer-events: all;
 }
 
 .load-state-indicator::before {

--- a/src/styles.css
+++ b/src/styles.css
@@ -194,6 +194,7 @@ input.interactive-stdin {
 
 .load-state-indicator.visible {
 	transform: translateX(0);
+	transform: translateX(var(--folding-offset, 0));
 	opacity: 1;
 	pointer-events: all;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -180,7 +180,7 @@ input.interactive-stdin {
 	border-bottom-left-radius: 4px;
 	color: var(--tx1);
 	transform: translateX(2em);
-	transition: transform 0.25s;
+	transition: transform 0.25s, opacity 0.25s;
 	opacity: 0;
 	pointer-events: none;
 	cursor: pointer;

--- a/src/styles.css
+++ b/src/styles.css
@@ -173,7 +173,7 @@ input.interactive-stdin {
 	position: absolute;
 	top: 0.1em;
 	left: -2em;
-	widtH: 2em;
+	width: 2em;
 	height: 2em;
 	background: var(--background-primary-alt);
 	border-top-left-radius: 4px;


### PR DESCRIPTION
I used some CSS changes to fix #150. This uses `opacity` to hide the running indicator: even though it's below the `<pre>` block, this is more robust against themes' changes. 

I'm not sure whether or not this is the same fix that @ZackYJz used. I didn't use their CSS, but I'm definitely willing to give co-author credit for the idea if it is the same. (zackyjz, please feel free to reply to this PR regarding that! :) )

I also fixed an issue with the Minimal Theme where fold padding would move the codeblock sideways, but *not* the indicator.