### PR TITLE
Fix input box show on print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 
 ## [1.3.0]
-## Added
+### Added
 - WSL support (thanks to @clohal)
 
-## Changed
+### Changed
 - Fix bug where recursion didn't work and some parts of the code couldn't be executed (Python executor's usage of `exec`/`eval`) (thanks to @clohal)
 - Fix formatting for the Scale section in the README.md (thanks to @cbarond)
 - Fix mixed up mathematica settings (thanks to @clohal)
 - Fix wrong setting for Mathematica
+- Improve styles (thanks to @milan338)
+- Refactor interactive executors to cut down on code reuse (thanks to @chlohal)
+- Fix Error Notif on Success (thanks to @clohal)
 
 ## [1.2.0] - 2022-10-19
 ### Added

--- a/src/Outputter.ts
+++ b/src/Outputter.ts
@@ -366,6 +366,6 @@ export class Outputter extends EventEmitter {
 
 		setTimeout(() => {
 			if (this.inputState === "OPEN") this.inputElement.style.display = "inline";
-		}, 1000)
+		}, 400)
 	}
 }

--- a/src/Outputter.ts
+++ b/src/Outputter.ts
@@ -355,6 +355,8 @@ export class Outputter extends EventEmitter {
 	 * @see {@link clear()}
 	 */
 	private makeOutputVisible() {
+        this.closeInput();
+
 		if (!this.clearButton) this.addClearButton();
 		if (!this.outputElement) this.addOutputElement();
 
@@ -364,6 +366,6 @@ export class Outputter extends EventEmitter {
 
 		setTimeout(() => {
 			if (this.inputState === "OPEN") this.inputElement.style.display = "inline";
-		}, 500)
+		}, 1000)
 	}
 }


### PR DESCRIPTION
I found that the input box always show and hide when I printing log with python. It is annoying. 

makeOutputVisible() method is called when write text to output element, input box always show on this method is called, after 
child process's work is done, closeInput() method is called. this is why input box show and hide.

To fix this issue, I add closeInput() at the start of makeOutputVisible() method, and increase input box show delay time.  before input box show, next makeOutputVisible() call, then closeInput() call, so the pre line input box will never show. 

Before:
![Obsidian_61W98tdHQF](https://user-images.githubusercontent.com/22113252/198826460-137ffa3b-bc23-42e8-aba3-3a8cb2b608be.gif)

After:
![Obsidian_qjKIoilkvG](https://user-images.githubusercontent.com/22113252/198826492-ec8a5b83-a63d-441c-8f06-e5e934bfa54c.gif)
