### PR TITLE
Remove ANSI escape codes from `stdout`

### DIFF
--- a/src/Outputter.ts
+++ b/src/Outputter.ts
@@ -111,6 +111,9 @@ export class Outputter extends EventEmitter {
 	 * @param text The stdout data in question
 	 */
 	private writeRaw(text: string) {
+		//remove ANSI escape codes
+		text = text.replace(/\x1b\\[;\d]*m/g, "")
+		
 		// Keep output field and clear button invisible if no text was printed.
 		if (this.textPrinted(text)) {
 			this.escapeAwareAppend(this.addStdout(), text);


### PR DESCRIPTION
This removes [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) from the `stdout` output.

This closes #169 