### PR TITLE
Add a magic command for the current Obsidian theme (light/dark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ The following magic commands are supported:
 - `@show(ImagePath, Width, Height)`: Displays an image at the given path in the note.
 - `@show(ImagePath, Width, Height, Alignment[center|left|right])`: Displays an image at the given path in the note.
 - `@html(HtmlSource)`: Displays HTML in the note
+- `@theme`: Inserts the color theme; either `"light"` or `"dark"`. For use with images, inline plots, and `@html()`.
 
 (`@show(...)` and `@html(...)` are only supported for JavaScript and Python yet.)
 

--- a/src/Vault.ts
+++ b/src/Vault.ts
@@ -21,10 +21,13 @@ export function getVaultVariables(app: App) {
 	const fileName = activeView.file.name
 	const filePath = activeView.file.path
 
+	const theme = document.body.classList.contains("theme-light") ? "light" : "dark";
+
 	return {
 		vaultPath: vaultPath,
 		folder: folder,
 		fileName: fileName,
 		filePath: filePath,
+		theme: theme
 	}
 }

--- a/src/transforms/Magic.ts
+++ b/src/transforms/Magic.ts
@@ -19,6 +19,7 @@ const HTML_REGEX = /@html\((?<html>[^)]+)\)/g;
 const VAULT_REGEX = /@vault/g
 const CURRENT_NOTE_REGEX = /@note/g;
 const NOTE_TITLE_REGEX = /@title/g;
+const COLOR_THEME_REGEX = /@theme/g;
 
 // Regex that are only used by one language.
 const PYTHON_PLOT_REGEX = /^(plt|matplotlib.pyplot|pyplot)\.show\(\)/gm;
@@ -63,6 +64,16 @@ export function insertNoteTitle(source: string, noteTitle: string): string {
 	return source.replace(NOTE_TITLE_REGEX, `"${t}"`);
 }
 
+/**
+ * Parses the source code for the @theme command and replaces it with the colour theme.
+ *
+ * @param source The source code to parse.
+ * @param noteTitle The current colour theme.
+ * @returns The transformed source code.
+ */
+export function insertColorTheme(source: string, theme: string): string {
+	return source.replace(COLOR_THEME_REGEX, `"${theme}"`);
+}
 
 /**
  * Add the @show command to python. @show is only supported in python and javascript.

--- a/src/transforms/Magic.ts
+++ b/src/transforms/Magic.ts
@@ -8,6 +8,7 @@
  * - `@vault`: Inserts the vault path as string.
  * - `@note`: Inserts the note path as string.
  * - `@title`: Inserts the note title as string.
+ * - `@theme`: Inserts the color theme; either `"light"` or `"dark"`. For use with images, inline plots, and `@html()`.
  */
 
 import * as os from "os";

--- a/src/transforms/TransformCode.ts
+++ b/src/transforms/TransformCode.ts
@@ -1,4 +1,4 @@
-import {insertNotePath, insertNoteTitle, insertVaultPath} from "./Magic";
+import {insertColorTheme, insertNotePath, insertNoteTitle, insertVaultPath} from "./Magic";
 import {getVaultVariables} from "src/Vault";
 import {canonicalLanguages} from 'src/main';
 import type {App} from "obsidian";
@@ -42,6 +42,7 @@ export function transformMagicCommands(app: App, srcCode: string) {
 		ret = insertVaultPath(ret, vars.vaultPath);
 		ret = insertNotePath(ret, vars.filePath);
 		ret = insertNoteTitle(ret, vars.fileName);
+		ret = insertColorTheme(ret, vars.theme);
 	} else {
 		console.warn(`Could not load all Vault variables! ${vars}`)
 	}


### PR DESCRIPTION
This PR adds a magic command for getting the current Obsidian theme. This helps inline plots and `@html()` users make their output blend into their notes.

This closes #187 