### PR TITLE
fix: reset current args

### DIFF
--- a/src/transforms/CodeInjector.ts
+++ b/src/transforms/CodeInjector.ts
@@ -151,7 +151,7 @@ export class CodeInjector {
 					currentLanguage = "";
 					currentCode = "";
 					insideCodeBlock = false;
-
+					currentArgs = {};
 				}
 
 				// reached start of code block


### PR DESCRIPTION
I found that it will notice that "Error: named export b1 exported more than once` when code like this:

\```python  {label='b1'}
code
\```
\```
other code
\```

it can be fixed by reset currentArgs.