### PR TITLE
fix: {pre} {post} {label} etc are not working begin with ‘run-’

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ data.json
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+*.log

--- a/src/transforms/TransformCode.ts
+++ b/src/transforms/TransformCode.ts
@@ -56,5 +56,19 @@ export function transformMagicCommands(app: App, srcCode: string) {
  * @returns The language of the code block.
  */
 export function getCodeBlockLanguage(firstLineOfCode: string) {
-	return getLanguageAlias(firstLineOfCode.split("```")[1].trim().split(" ")[0].split("{")[0])
+	let currentLanguage: string = firstLineOfCode.split("```")[1].trim().split(" ")[0].split("{")[0];
+	if (isStringNotEmpty(currentLanguage) && currentLanguage.startsWith("run-")) {
+		currentLanguage = currentLanguage.replace("run-", "");
+	}
+	return getLanguageAlias(currentLanguage);
+}
+
+/**
+ * Check if a string is not empty
+ *
+ * @param str Input string
+ * @returns True when string not empty, False when the string is Empty
+ */
+export function isStringNotEmpty(str: string): boolean {
+	return !!str && str.trim().length > 0;
 }


### PR DESCRIPTION
fix: {pre} {post} {label} etc are not working when language annotation begin with ‘run-’

related issue: https://github.com/twibiral/obsidian-execute-code/issues/179#issue-1457698922

https://github.com/twibiral/obsidian-execute-code/pull/271