### PR TITLE
Add OCaml support

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,16 @@ plot2d(sin(x), [x,0,%pi]);
 
 </details>
 
+<details>
+<summary>OCaml</summary>
+
+- Requirements: OCaml is installed and the correct path is set in the settings.
+
+```ocaml
+print_endline "Hello, OCaml!"
+```
+</details>
+
 
 Squiggle: For Squiggle support take a look at the [Obsidian Squiggle plugin](https://github.com/jqhoogland/obsidian-squiggle) by @jqhoogland.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The result is shown only after the execution is finished. It is not possible to 
 ![Video that shows how the plugin works.](https://github.com/twibiral/obsidian-execute-code/blob/master/images/execute_code_example.gif?raw=true)
 
 
-The following [languages are supported](#supported-programming-languages-): C, CPP, Dart, Golang, Groovy, Kotlin, Java, JavaScript, TypeScript, Lean, Lua, CSharp, Prolog, Rust, Python, R, Ruby, Wolfram Mathematica, Haskell, Scala, Racket, F#, Batch, Shell & Powershell, Octave, Maxima and Zig.
+The following [languages are supported](#supported-programming-languages-): C, CPP, Dart, Golang, Groovy, Kotlin, Java, JavaScript, TypeScript, Lean, Lua, CSharp, Prolog, Rust, Python, R, Ruby, Wolfram Mathematica, Haskell, Scala, Racket, F#, Batch, Shell & Powershell, Octave, Maxima, Zig and OCaml.
 
 
 Python, Rust, and Octave support embedded plots. All languages support ["magic" commands](#magic-commands-) that help you to access paths in obsidian or show images in your notes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "execute-code",
-			"version": "1.9.0",
+			"version": "1.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"g": "^2.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ import runAllCodeBlocks from './runAllCodeBlocks';
 export const languageAliases = ["javascript", "typescript", "bash", "csharp", "wolfram", "nb", "wl", "hs", "py", "scpt"] as const;
 export const canonicalLanguages = ["js", "ts", "cs", "lean", "lua", "python", "cpp", "prolog", "shell", "groovy", "r",
 	"go", "rust", "java", "powershell", "kotlin", "mathematica", "haskell", "scala", "racket", "fsharp", "c", "dart",
-	"ruby", "batch", "sql", "octave", "maxima", "applescript", "zig"] as const;
+	"ruby", "batch", "sql", "octave", "maxima", "applescript", "zig", "ocaml"] as const;
 export const supportedLanguages = [...languageAliases, ...canonicalLanguages] as const;
 export type LanguageId = typeof canonicalLanguages[number];
 
@@ -402,6 +402,12 @@ export default class ExecuteCodePlugin extends Plugin {
 				button.className = runButtonDisabledClass;
 				const transformedCode = await new CodeInjector(this.app, this.settings, language).injectCode(srcCode);
 				this.runCodeInShell(transformedCode, out, button, this.settings.zigPath, this.settings.zigArgs, "zig", language, file);
+			})
+		} else if (language === "ocaml") {
+			button.addEventListener("click", async () => {
+				button.className = runButtonDisabledClass;
+				const transformedCode = await new CodeInjector(this.app, this.settings, language).injectCode(srcCode);
+				this.runCodeInShell(transformedCode, out, button, this.settings.ocamlPath, this.settings.ocamlArgs, "ocaml", language, file);
 			})
 		}
 

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -132,6 +132,9 @@ export interface ExecutorSettings {
 	zigPath: string;
 	zigArgs: string;
 	zigInject: string;
+	ocamlPath: string;
+	ocamlArgs: string;
+	ocamlInject: string;
 
 	jsInteractive: boolean;
 	tsInteractive: boolean;
@@ -164,6 +167,7 @@ export interface ExecutorSettings {
 	maximaInteractive: boolean;
 	applescriptInteractive: boolean;
 	zigInteractive: boolean;
+	ocamlInteractive: boolean;
 }
 
 
@@ -299,6 +303,9 @@ export const DEFAULT_SETTINGS: ExecutorSettings = {
 	zigPath: "zig",
 	zigArgs: "run",
 	zigInject: "",
+	ocamlPath: "ocaml",
+	ocamlArgs: "",
+	ocamlInject: "",
 	jsInteractive: true,
 	tsInteractive: false,
 	csInteractive: false,
@@ -330,4 +337,5 @@ export const DEFAULT_SETTINGS: ExecutorSettings = {
 	maximaInteractive: false,
 	applescriptInteractive: false,
 	zigInteractive: false,
+	ocamlInteractive: false,
 }

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -32,6 +32,7 @@ import makeOctaviaSettings from "./per-lang/makeOctaveSettings";
 import makeMaximaSettings from "./per-lang/makeMaximaSettings";
 import makeApplescriptSettings from "./per-lang/makeApplescriptSettings";
 import makeZigSettings from "./per-lang/makeZigSettings";
+import makeOCamlSettings from "./per-lang/makeOCamlSettings";
 
 
 /**
@@ -221,6 +222,9 @@ export class SettingsTab extends PluginSettingTab {
 
 		// ========== Zig ============
 		makeZigSettings(this, this.makeContainerFor("zig"));
+
+		// ========== OCaml ============
+		makeOCamlSettings(this, this.makeContainerFor("ocaml"));
 
 		this.focusContainer(this.plugin.settings.lastOpenLanguageTab || canonicalLanguages[0]);
 	}

--- a/src/settings/languageDisplayName.ts
+++ b/src/settings/languageDisplayName.ts
@@ -31,4 +31,5 @@ export const DISPLAY_NAMES: Record<LanguageId, string> = {
 	maxima: "Maxima",
     applescript: "Applescript",
 	zig: "Zig",
+	ocaml: "OCaml",
 } as const;

--- a/src/settings/per-lang/makeOCamlSettings.ts
+++ b/src/settings/per-lang/makeOCamlSettings.ts
@@ -1,0 +1,27 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'OCaml Settings' });
+    new Setting(containerEl)
+        .setName('ocaml path')
+        .setDesc("Path to your ocaml installation")
+        .addText(text => text
+            .setValue(tab.plugin.settings.ocamlPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.ocamlPath = sanitized;
+                console.log('ocaml path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('ocaml arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.ocamlArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.ocamlArgs = value;
+                console.log('ocaml args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting(containerEl, "ocaml");
+}


### PR DESCRIPTION
Basic support for OCaml through [ocaml](https://www.ocamlwiki.com/wiki/Interpreter) interpreter.

Tested on NixOS.

![image](https://github.com/twibiral/obsidian-execute-code/assets/48822818/87a84c1b-9d2e-4b72-892c-7208ade7b2ac)

Based on [previous PR for Zig](https://github.com/twibiral/obsidian-execute-code/pull/299).