### PR TITLE
Replaced Windows file separator with path.join in Executor.getTempFile

### DIFF
--- a/src/executors/Executor.ts
+++ b/src/executors/Executor.ts
@@ -1,6 +1,7 @@
 import {Notice} from "obsidian";
 import {Outputter} from "src/Outputter";
 import * as os from "os";
+import * as path from "path";
 import {LanguageId} from "src/main";
 import {EventEmitter} from "stream";
 
@@ -63,6 +64,6 @@ export default abstract class Executor extends EventEmitter {
 	protected getTempFile(ext: string) {
 		if (this.tempFileId === undefined)
 			this.tempFileId = Date.now().toString();
-		return `${os.tmpdir()}\\temp_${this.tempFileId}.${ext}`;
+		return path.join(os.tmpdir(), `temp_${this.tempFileId}.${ext}`);
 	}
 }


### PR DESCRIPTION
**Description**:

All code snippets failed to execute on Mac with the error:
```
/usr/local/bin/bash: /var/folders/gy/5n_nrgl56d9f7_m2df17001w0000gr/Ttemp_1715619532117.sh: No such file or directory
```

**Solution**:

A previous commit (59414abba95ee3caf5ecedf259016c2bfdd119ee) hard-coded the Windows file separator (`\`) in `Executor.getTempFile`.

This change replaces the Windows file separator with the Node built-in `path.join` so the `getTempFile` will automatically use the correct OS file separator.

**Testing**:

1. clone and make changes locally
2. `npm ci`
3. `npm run build`
4. `cp main.js <vaultpath>/.obsidian/plugins/execute-code/`
5. reload extension and execute snippet

Fixes twibiral/obsidian-execute-code#347

---

Edit: tested successfully on Windows 10 as well