### PR TITLE
feat: have %USERNAME% be usable for python path

### DIFF
--- a/src/executors/ReplExecutor.ts
+++ b/src/executors/ReplExecutor.ts
@@ -24,6 +24,9 @@ export default abstract class ReplExecutor extends AsyncExecutor {
             path = "wsl";
         }
 
+        // Replace %USERNAME% with actual username
+        path = path.replace("%USERNAME%", process.env.USERNAME);
+
 		// Spawns a new REPL that is used to execute code.
 		// {env: process.env} is used to ensure that the environment variables are passed to the REPL.
         this.process = spawn(path, args, {env: process.env});


### PR DESCRIPTION
This commit updates python path to be more flexible by replacing instances of `%USERNAME%` with the actual user of the PC.
Instead of typing `C:/Users/user/AppData/Local/Programs/Python/Python311/python.exe`, one could use `C:/Users/%USERNAME%/AppData/Local/Programs/Python/Python311/python.exe`.

Useful for those who use multiple devices (that do not have the same name for whatever reason) synced through OneDrive or something similar.