### PR TITLE
Prevent killWithChildren from needless throwing

### DIFF
--- a/src/executors/killWithChildren.ts
+++ b/src/executors/killWithChildren.ts
@@ -4,7 +4,14 @@ export default (pid: number) => {
     if(process.platform === "win32") {
         execSync(`taskkill /pid ${pid} /T /F`)
     } else {
-        execSync(`pkill -P ${pid}`)
+		try {
+	        execSync(`pkill -P ${pid}`)
+		} catch(err) {
+			// An error code of 1 signifies that no children were found to kill
+			// In this case, ignore the error
+			// Otherwise, re-throw it.
+			if (err.status !== 1) throw err;
+		}
         process.kill(pid);
     }
 }


### PR DESCRIPTION
The `pkill` command seems to return a 1 error code when it cannot any matching processes.
[reference](https://manpages.org/pkill)

In this case, if the runtime environment has not spawned any child processes then it will return a 1 error-code, causing execSync to throw an error and prevent the runtime from getting killed.

Here we ignore the 1 error code and rethrow any other errors.