### PR TITLE
File Contents as new magic command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,48 @@
 				"builtin-modules": "^3.3.0",
 				"esbuild": "0.15.8",
 				"obsidian": "latest",
+				"obsidian-typings": "^2.3.1-beta.1",
 				"parallelshell": "^3.0.1",
 				"tslib": "2.4.0",
 				"typescript": "^4.8.3"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+			"integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.14.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@capacitor/core": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@capacitor/core/-/core-6.2.0.tgz",
+			"integrity": "sha512-B9IlJtDpUqhhYb+T8+cp2Db/3RETX36STgjeU2kQZBs/SLAcFiMama227o+msRjLeo3DO+7HJjWVA1+XlyyPEg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@codemirror/search": {
+			"version": "6.5.8",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.8.tgz",
+			"integrity": "sha512-PoWtZvo7c1XFeZWmmyaOp2G0XVbOnm+fJzvghqGAktBW3cufwJUWvSCcNG0ppXiBEM05mZu6RhMtXPv2hpllig==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0",
+				"crelt": "^1.0.5"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -46,6 +85,40 @@
 				"@codemirror/state": "^6.4.0",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@electron/get": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+			"integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"got": "^11.8.5",
+				"progress": "^2.0.3",
+				"semver": "^6.2.0",
+				"sumchecker": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"global-agent": "^3.0.0"
+			}
+		},
+		"node_modules/@electron/get/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -229,6 +302,48 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
+		"node_modules/@szmarczak/http-timer": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"defer-to-connect": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@types/cacheable-request": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+			"integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "^3.1.4",
+				"@types/node": "*",
+				"@types/responselike": "^1.0.0"
+			}
+		},
 		"node_modules/@types/codemirror": {
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
@@ -246,12 +361,31 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/http-cache-semantics": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/keyv": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/node": {
 			"version": "18.19.64",
@@ -261,6 +395,17 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/@types/responselike": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+			"integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/semver": {
@@ -278,6 +423,26 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "*"
+			}
+		},
+		"node_modules/@types/turndown": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.5.tgz",
+			"integrity": "sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -581,6 +746,16 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/boolean": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+			"integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -606,6 +781,17 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/builtin-modules": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -617,6 +803,37 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cacheable-lookup": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.6.0"
+			}
+		},
+		"node_modules/cacheable-request": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^4.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/callsites": {
@@ -648,6 +865,20 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/clone-response": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -674,6 +905,14 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/crelt": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -712,12 +951,103 @@
 				}
 			}
 		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/decompress-response/node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/defer-to-connect": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/detect-node": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
 			"peer": true
 		},
 		"node_modules/dir-glob": {
@@ -746,6 +1076,100 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/electron": {
+			"version": "33.2.1",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-33.2.1.tgz",
+			"integrity": "sha512-SG/nmSsK9Qg1p6wAW+ZfqU+AV8cmXMTIklUL18NnOKfZLlum4ZsDoVdmmmlL39ZmeCaq27dr7CgslRPahfoVJg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@electron/get": "^2.0.0",
+				"@types/node": "^20.9.0",
+				"extract-zip": "^2.0.1"
+			},
+			"bin": {
+				"electron": "cli.js"
+			},
+			"engines": {
+				"node": ">= 12.20.55"
+			}
+		},
+		"node_modules/electron/node_modules/@types/node": {
+			"version": "20.17.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
+			"integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~6.19.2"
+			}
+		},
+		"node_modules/electron/node_modules/undici-types": {
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/esbuild": {
 			"version": "0.15.8",
@@ -1358,6 +1782,28 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1420,6 +1866,17 @@
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"pend": "~1.2.0"
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -1491,6 +1948,22 @@
 			"license": "ISC",
 			"peer": true
 		},
+		"node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1504,6 +1977,23 @@
 			"resolved": "https://registry.npmjs.org/g/-/g-2.0.1.tgz",
 			"integrity": "sha512-Fi6Ng5fZ/ANLQ15H11hCe+09sgUoNvDEBevVgx3KoYOhsH5iLNPn54hx0jPZ+3oSWr+xajnp2Qau9VmPsc7hTA==",
 			"license": "MIT"
+		},
+		"node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/glob": {
 			"version": "7.2.3",
@@ -1542,6 +2032,26 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/global-agent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+			"integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"boolean": "^3.0.1",
+				"es6-error": "^4.1.1",
+				"matcher": "^3.0.0",
+				"roarr": "^2.15.3",
+				"semver": "^7.3.2",
+				"serialize-error": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=10.0"
+			}
+		},
 		"node_modules/globals": {
 			"version": "13.24.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -1557,6 +2067,25 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/globalthis": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"define-properties": "^1.2.1",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/globby": {
@@ -1580,6 +2109,56 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/got": {
+			"version": "11.8.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+			"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true
+		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -1596,6 +2175,69 @@
 			"peer": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/http-cache-semantics": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true
+		},
+		"node_modules/http2-wrapper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			}
+		},
+		"node_modules/i18next": {
+			"version": "23.16.8",
+			"resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+			"integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://locize.com"
+				},
+				{
+					"type": "individual",
+					"url": "https://locize.com/i18next.html"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.23.2"
 			}
 		},
 		"node_modules/ignore": {
@@ -1748,6 +2390,15 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/json5": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1758,6 +2409,17 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"node_modules/keyv": {
@@ -1811,6 +2473,32 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/lowercase-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/matcher": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+			"integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"escape-string-regexp": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1833,6 +2521,17 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/minimatch": {
@@ -1880,6 +2579,32 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/normalize-url": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/obsidian": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.7.2.tgz",
@@ -1893,6 +2618,23 @@
 			"peerDependencies": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0"
+			}
+		},
+		"node_modules/obsidian-typings": {
+			"version": "2.3.1-beta.1",
+			"resolved": "https://registry.npmjs.org/obsidian-typings/-/obsidian-typings-2.3.1-beta.1.tgz",
+			"integrity": "sha512-0S82fAa20gKeaxoAR/WgwarazIu8Uidjm7EggWlmtN46gPGI0nzsKIzQKDt8YonDuW202W554QXRbqbCB90wDg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@capacitor/core": "^6.1.2",
+				"@codemirror/search": "^6.5.6",
+				"@codemirror/state": "^6.4.1",
+				"@types/node": ">=14.0.0",
+				"@types/turndown": "^5.0.5",
+				"electron": ">=1.6.10",
+				"i18next": "^23.15.1",
+				"obsidian": "^1.7.2"
 			}
 		},
 		"node_modules/obsidian/node_modules/moment": {
@@ -1940,6 +2682,17 @@
 			"resolved": "https://registry.npmjs.org/original-fs/-/original-fs-1.2.0.tgz",
 			"integrity": "sha512-IGo+qFumpIV65oDchJrqL0BOk9kr82fObnTesNJt8t3YgP6vfqcmRs0ofPzg3D9PKMeBHt7lrg1k/6L+oFdS8g==",
 			"license": "Unlicense"
+		},
+		"node_modules/p-cancelable": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
@@ -2042,6 +2795,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2064,6 +2825,29 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/pump": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+			"integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
 			}
 		},
 		"node_modules/punycode": {
@@ -2098,6 +2882,20 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/readline-sync": {
 			"version": "1.4.9",
 			"resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz",
@@ -2106,6 +2904,22 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
+		},
+		"node_modules/regenerator-runtime": {
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/resolve-alpn": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
@@ -2116,6 +2930,20 @@
 			"peer": true,
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/responselike": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"lowercase-keys": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/reusify": {
@@ -2145,6 +2973,26 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/roarr": {
+			"version": "2.15.4",
+			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+			"integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"boolean": "^3.0.1",
+				"detect-node": "^2.0.4",
+				"globalthis": "^1.0.1",
+				"json-stringify-safe": "^5.0.1",
+				"semver-compare": "^1.0.0",
+				"sprintf-js": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=8.0"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -2184,6 +3032,48 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/serialize-error": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"type-fest": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/serialize-error/node_modules/type-fest": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2218,6 +3108,15 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
@@ -2254,6 +3153,20 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/sumchecker": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+			"integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.1.0"
+			},
+			"engines": {
+				"node": ">= 8.0"
+			}
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -2378,6 +3291,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2432,6 +3356,18 @@
 			"dev": true,
 			"license": "ISC",
 			"peer": true
+		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"builtin-modules": "^3.3.0",
 		"esbuild": "0.15.8",
 		"obsidian": "latest",
+		"obsidian-typings": "^2.3.1-beta.1",
 		"parallelshell": "^3.0.1",
 		"tslib": "2.4.0",
 		"typescript": "^4.8.3"

--- a/src/Vault.ts
+++ b/src/Vault.ts
@@ -2,6 +2,22 @@ import type {App, FileSystemAdapter} from "obsidian";
 import {MarkdownView} from "obsidian";
 
 /**
+* Get the full HTML content of the current MarkdownView
+*
+* @param view - The MarkdownView to get the HTML from
+* @returns The full HTML of the MarkdownView
+*/
+function getFullContentHtml(view: MarkdownView): string {
+	const codeMirror = view.editor.cm;
+	codeMirror.viewState.printing = true;
+	codeMirror.measure();
+	const html = view.contentEl.innerHTML;
+	codeMirror.viewState.printing = false;
+	codeMirror.measure();
+	return html;
+}
+
+/**
  * Tries to get the active view from obsidian and returns a dictionary containing the file name, folder path,
  * file path, and vault path of the currently opened / focused note.
  *
@@ -20,7 +36,7 @@ export function getVaultVariables(app: App) {
 	const folder = activeView.file.parent.path;
 	const fileName = activeView.file.name
 	const filePath = activeView.file.path
-	const fileContent = activeView.editor.getValue();
+	const fileContent = getFullContentHtml(activeView);
 
 	const theme = document.body.classList.contains("theme-light") ? "light" : "dark";
 

--- a/src/Vault.ts
+++ b/src/Vault.ts
@@ -6,8 +6,8 @@ import {MarkdownView} from "obsidian";
  * file path, and vault path of the currently opened / focused note.
  *
  * @param app The current app handle (this.app from ExecuteCodePlugin)
- * @returns { fileName: string; folder: string; filePath: string; vaultPath: string } A dictionary containing the
- * file name, folder path, file path, and vault path of the currently opened / focused note.
+ * @returns { fileName: string; folder: string; filePath: string; vaultPath: string; fileContent: string } A dictionary containing the
+ * file name, folder path, file path, vault pat, and file content of the currently opened / focused note.
  */
 export function getVaultVariables(app: App) {
 	const activeView = app.workspace.getActiveViewOfType(MarkdownView);
@@ -20,6 +20,7 @@ export function getVaultVariables(app: App) {
 	const folder = activeView.file.parent.path;
 	const fileName = activeView.file.name
 	const filePath = activeView.file.path
+	const fileContent = activeView.editor.getValue();
 
 	const theme = document.body.classList.contains("theme-light") ? "light" : "dark";
 
@@ -28,6 +29,7 @@ export function getVaultVariables(app: App) {
 		folder: folder,
 		fileName: fileName,
 		filePath: filePath,
-		theme: theme
+		theme: theme,
+		fileContent: fileContent
 	}
 }

--- a/src/transforms/Magic.ts
+++ b/src/transforms/Magic.ts
@@ -25,7 +25,7 @@ const CURRENT_NOTE_REGEX = /@note/g;
 const CURRENT_NOTE_PATH_REGEX = /@note_path/g;
 const CURRENT_NOTE_URL_REGEX = /@note_url/g;
 const NOTE_TITLE_REGEX = /@title/g;
-const NOTE_CONTENT_REGEX = /@note_content/g;
+const NOTE_CONTENT_REGEX = /@content/g;
 const COLOR_THEME_REGEX = /@theme/g;
 
 // Regex that are only used by one language.

--- a/src/transforms/Magic.ts
+++ b/src/transforms/Magic.ts
@@ -25,6 +25,7 @@ const CURRENT_NOTE_REGEX = /@note/g;
 const CURRENT_NOTE_PATH_REGEX = /@note_path/g;
 const CURRENT_NOTE_URL_REGEX = /@note_url/g;
 const NOTE_TITLE_REGEX = /@title/g;
+const NOTE_CONTENT_REGEX = /@note_content/g;
 const COLOR_THEME_REGEX = /@theme/g;
 
 // Regex that are only used by one language.
@@ -78,6 +79,18 @@ export function insertNoteTitle(source: string, noteTitle: string): string {
 		t = noteTitle.split(".").slice(0, -1).join(".");
 
 	return source.replace(NOTE_TITLE_REGEX, `"${t}"`);
+}
+
+/**
+ * Parses the source code and replaces the NOTE_CONTENT_REGEX with the file content.
+ *
+ * @param source The source code to parse.
+ * @param content The content of the note.
+ * @returns The transformed source code.
+ */
+export function insertNoteContent(source: string, content: string): string {
+	const escaped_content = JSON.stringify(content)
+	return source.replace(NOTE_CONTENT_REGEX, `${escaped_content}`)
 }
 
 /**

--- a/src/transforms/TransformCode.ts
+++ b/src/transforms/TransformCode.ts
@@ -1,4 +1,4 @@
-import {insertColorTheme, insertNotePath, insertNoteTitle, insertVaultPath} from "./Magic";
+import {insertColorTheme, insertNotePath, insertNoteTitle, insertVaultPath, insertNoteContent} from "./Magic";
 import {getVaultVariables} from "src/Vault";
 import {canonicalLanguages} from 'src/main';
 import type {App} from "obsidian";
@@ -43,6 +43,7 @@ export function transformMagicCommands(app: App, srcCode: string) {
 		ret = insertNotePath(ret, vars.filePath);
 		ret = insertNoteTitle(ret, vars.fileName);
 		ret = insertColorTheme(ret, vars.theme);
+		ret = insertNoteContent(ret, vars.fileContent);
 	} else {
 		console.warn(`Could not load all Vault variables! ${vars}`)
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
 			"ES5",
 			"ES6",
 			"ES7"
-		]
+		],
+		"types": ["obsidian-typings"]
 	},
 	"include": [
 		"**/*.ts",


### PR DESCRIPTION
Hi, I don't know if this feature is wanted or not, but I used it myself and wanted to share. It's a simple extension to have the note's content available as the `@content` magic command. This is a swiss army knife (if admittedly an a bit cumbersome one) to process your note's content. You can do table processing, read data from your lists, access any html ids you create, etc. Unfortunately obsidian block ids don't show up in the html. Other extensions also have issues with this (see eg [here](https://github.com/KosmosisDire/obsidian-webpage-export/issues/57)). I decided to pass the rendered html instead of the raw markdown string because most programming languages have better support for parsing and postprocessing html dom. 

Some examples of how it looks like:

![image](https://github.com/user-attachments/assets/e97fd550-96d3-4d1e-98a5-3a8b3aef0393)

![image](https://github.com/user-attachments/assets/0a7c766a-6d18-4bd4-967d-96623d7c9441)

