### PR TITLE
fix: CppExecutor not read the cppArgs from settings

### DIFF
--- a/src/executors/CppExecutor.ts
+++ b/src/executors/CppExecutor.ts
@@ -9,6 +9,6 @@ export default class CppExecutor extends ClingExecutor {
 	}
 	
 	override run(codeBlockContent: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string) {
-		return super.run(codeBlockContent, outputter, cmd, `-std=${this.settings.clingStd} ${cmdArgs}`, "cpp");
+		return super.run(codeBlockContent, outputter, cmd, `-std=${this.settings.clingStd} ${cmdArgs} ${this.settings[`cppArgs`]}`, "cpp");
 	}
 }


### PR DESCRIPTION
When I compile C++ code and set some compile args in settings, I find this plugin will not apply my config. I fixed it, Now it working pretty good