### PR TITLE
feat: add GCC support for C++ and include style.css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
 	"name": "execute-code",
+	"version": "2.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "execute-code",
-			"version": "2.0.0",
+			"version": "2.1.2",
 			"license": "MIT",
 			"dependencies": {
 				"g": "^2.0.1",
@@ -4242,6 +4243,5 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		}
-	},
-	"version": "2.1.2"
+	}
 }

--- a/src/executors/ClingExecutor.ts
+++ b/src/executors/ClingExecutor.ts
@@ -1,3 +1,5 @@
+// i think we should have Cling-executor and g++executor instead of remove cling like 
+// https://github.com/raccoonhands1/obsidian-execute-code-enhanced
 import NonInteractiveCodeExecutor from './NonInteractiveCodeExecutor';
 import * as child_process from "child_process";
 import type {ChildProcessWithoutNullStreams} from "child_process";

--- a/src/executors/CppExecutor.ts
+++ b/src/executors/CppExecutor.ts
@@ -1,14 +1,40 @@
 import type { Outputter } from "src/output/Outputter";
 import type { ExecutorSettings } from "src/settings/Settings";
 import ClingExecutor from './ClingExecutor';
+import GppExecutor from './G++Executor';
 
-export default class CppExecutor extends ClingExecutor {
+class ClingConcrete extends ClingExecutor {
+    constructor(settings: ExecutorSettings, file: string) {
+        super(settings, file, "cpp");
+    }
+}
 
-	constructor(settings: ExecutorSettings, file: string) {
-		super(settings, file, "cpp");
-	}
-	
-	override run(codeBlockContent: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string) {
-		return super.run(codeBlockContent, outputter, cmd, `-std=${this.settings.clingStd} ${cmdArgs}`, "cpp");
-	}
+export default class CppExecutor extends GppExecutor {
+    private clingEngine: ClingConcrete;
+
+    constructor(settings: ExecutorSettings, file: string) {
+        super(settings, file, "cpp");
+        this.clingEngine = new ClingConcrete(settings, file);
+    }
+
+    override run(codeBlockContent: string, outputter: Outputter, cmd: string, cmdArgs: string, ext: string) {
+        const path = this.settings.clingPath || "";
+        const isCling = path.toLowerCase().includes("cling");
+
+        if (isCling) {
+            // Cling 
+            const std = this.settings.clingStd || "c++17";
+            const args = `-std=${std} ${cmdArgs}`;
+            console.log("Using Cling execution...");
+            return this.clingEngine.run(codeBlockContent, outputter, path, args, "cpp");
+        } else {
+            // G++ 
+            const std = this.settings.gppStd || "c++17";
+            const args = `-std=${std} ${cmdArgs}`;
+            const gppPath = this.settings.gppPath || "g++"; 
+            console.log("Using G++ compilation...");
+            return super.run(codeBlockContent, outputter, gppPath, args, "cpp");
+        }
+
+    }
 }

--- a/src/executors/G++Executor.ts
+++ b/src/executors/G++Executor.ts
@@ -1,0 +1,174 @@
+import Executor from './Executor';
+import * as child_process from "child_process";
+import type { ChildProcessWithoutNullStreams } from "child_process";
+import type { Outputter } from "src/output/Outputter";
+import type { ExecutorSettings } from "src/settings/Settings";
+import * as path from "path";
+import * as os from "os";
+import { Notice } from "obsidian";
+
+export default abstract class GppExecutor extends Executor {
+	// Rotation counter for shared output files (cycles through 0, 1, 2)
+	private static rotationIndex: number = 0;
+
+	language: "cpp" | "c"
+	settings: ExecutorSettings;
+	usesShell: boolean = false;
+	stdoutCb: (chunk: any) => void;
+	stderrCb: (chunk: any) => void;
+	resolveRun: (value: void | PromiseLike<void>) => void | undefined = undefined;
+
+	constructor(settings: ExecutorSettings, file: string, language: "c" | "cpp") {
+		super(file, language);
+		this.settings = settings;
+	}
+
+	stop(): Promise<void> {
+		return Promise.resolve();
+	}
+
+	/**
+	 * Get the next output file in rotation (shared1.out, shared2.out, shared3.out)
+	 * Files are stored in the OS temp directory (e.g., /tmp/)
+	 */
+	private getNextOutputFile(): string {
+		const index = (GppExecutor.rotationIndex % 3) + 1; // Returns 1, 2, or 3
+		GppExecutor.rotationIndex++;
+		
+		// Use OS temp directory to avoid ASAR archive issues with Electron
+		return path.join(os.tmpdir(), `shared${index}.out`);
+	}
+
+	override run(codeBlockContent: string, outputter: Outputter, _cmd: string, args: string, ext: string) {
+		console.log("G++Executor: run() called");
+		// Resolve any currently running blocks
+		if (this.resolveRun !== undefined)
+			this.resolveRun();
+		this.resolveRun = undefined;
+
+		return new Promise<void>((resolve, _reject) => {
+			console.log("G++Executor: Starting compilation");
+			outputter.clear();
+
+			// For g++, we don't rename main() - code must have a main() function
+			const code = codeBlockContent;
+
+			// Get the next rotating output file
+			const outputFile = this.getNextOutputFile();
+			
+			// Determine language flag for g++ (-x c++ or -x c)
+			const langFlag = ext === "cpp" || ext === "c++" ? "c++" : "c";
+			
+			// Build compilation arguments
+			// Format: g++ -x {c++|c} -o <output_file> <user_args> -
+			const compileArgs = [
+				`-x`, langFlag,           // Explicitly specify language
+				`-o`, outputFile,         // Output to rotating shared file
+				...args.split(" ").filter(arg => arg.length > 0), // User-provided args
+				`-`                       // Read source from stdin
+			];
+
+			// Spawn g++ compiler
+			const compileChild = child_process.spawn(this.settings.gppPath, compileArgs, {
+				env: process.env,
+				shell: this.usesShell
+			});
+
+			let compileStderr = "";
+
+			// Capture compilation errors
+			compileChild.stderr.on('data', (data) => {
+				compileStderr += data.toString();
+			});
+
+			compileChild.on('error', (err) => {
+				new Notice("Compilation Error!");
+				outputter.writeErr(err.toString());
+				outputter.closeInput();
+				resolve();
+			});
+
+			compileChild.on('close', (code) => {
+				console.log("G++Executor: Compilation finished with code", code);
+				if (code !== 0) {
+					// Compilation failed - show errors to user
+					new Notice("Compilation Error!");
+					outputter.writeErr(compileStderr);
+					outputter.closeInput();
+					console.log("G++Executor: Compilation failed, resolving promise");
+					resolve();
+				} else {
+					// Compilation succeeded - execute the compiled binary
+					console.log("G++Executor: Compilation succeeded, spawning executable");
+					const executeChild = child_process.spawn(outputFile, [], {
+						env: process.env,
+						shell: this.usesShell
+					});
+
+					// Handle execution output (don't wait for it to finish)
+					this.handleChildOutput(executeChild, outputter);
+					
+					// Resolve immediately after spawning execution
+					console.log("G++Executor: Execution spawned, resolving promise");
+					resolve();
+				}
+			});
+
+			// Write source code to compiler's stdin
+			compileChild.stdin.write(code);
+			compileChild.stdin.end();
+		});
+	}
+
+	/**
+	 * Handles the output of the executing child process and redirects stdout and stderr to the Outputter.
+	 * Returns a Promise that resolves when the child process closes.
+	 */
+	protected handleChildOutput(child: ChildProcessWithoutNullStreams, outputter: Outputter): Promise<void> {
+		return new Promise<void>((resolve) => {
+			// Kill process on clear button click
+			outputter.killBlock = () => {
+				child.kill('SIGINT');
+			}
+
+			this.stdoutCb = (data) => {
+				outputter.write(data.toString());
+			};
+			
+			this.stderrCb = (data) => {
+				outputter.writeErr(data.toString());
+			};
+
+			child.stdout.on('data', this.stdoutCb);
+			child.stderr.on('data', this.stderrCb);
+
+			// Allow user input to be passed to the executing program
+			outputter.on("data", (data: string) => {
+				child.stdin.write(data);
+			});
+
+			child.on('exit', (code) => {
+				console.log("G++Executor: Child process exited with code", code);
+			});
+
+			child.on('close', (code) => {
+				console.log("G++Executor: Child process closed with code", code);
+				if (code !== 0)
+					new Notice("Execution Error!");
+
+				outputter.closeInput();
+
+				// Resolve both the handleChildOutput promise and the run promise
+				console.log("G++Executor: Resolving handleChildOutput promise");
+				resolve();
+			});
+
+			child.on('error', (err) => {
+				console.error("G++Executor: Child process error", err);
+				new Notice("Execution Error!");
+				outputter.writeErr(err.toString());
+				resolve(); // Also resolve on error to prevent hanging
+			});
+		});
+	}
+}

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -115,6 +115,9 @@ export interface ExecutorSettings {
 	clingPath: string;
 	clingArgs: string;
 	clingStd: string;
+    gppPath: string;
+    gppArgs: string;
+    gppStd: string;
 	rustFileExtension: string,
 	RPath: string;
 	RArgs: string;
@@ -320,6 +323,9 @@ export const DEFAULT_SETTINGS: ExecutorSettings = {
 	clingPath: "cling",
 	clingArgs: "",
 	clingStd: "c++17",
+    gppPath: "g++",
+    gppArgs: "",
+    gppStd: "c++17",
 	rustFileExtension: "rs",
 	RPath: "Rscript",
 	RArgs: "",

--- a/src/settings/per-lang/makeCppSettings.ts
+++ b/src/settings/per-lang/makeCppSettings.ts
@@ -5,7 +5,7 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
     containerEl.createEl('h3', { text: 'C++ Settings' });
     new Setting(containerEl)
         .setName('Cling path')
-        .setDesc('The path to your Cling installation.')
+        .setDesc('The path to your gcc/Cling installation.')
         .addText(text => text
             .setValue(tab.plugin.settings.clingPath)
             .onChange(async (value) => {
@@ -15,7 +15,7 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 await tab.plugin.saveSettings();
             }));
     new Setting(containerEl)
-        .setName('Cling arguments for C++')
+        .setName('gcc/Cling arguments for C++')
         .addText(text => text
             .setValue(tab.plugin.settings.cppArgs)
             .onChange(async (value) => {
@@ -24,7 +24,7 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
                 await tab.plugin.saveSettings();
             }));
     new Setting(containerEl)
-        .setName('Cling std')
+        .setName('gcc/Cling std')
         .addDropdown(dropdown => dropdown
 			.addOption('c++98', 'C++ 98')
             .addOption('c++11', 'C++ 11')
@@ -34,7 +34,7 @@ export default (tab: SettingsTab, containerEl: HTMLElement) => {
             .setValue(tab.plugin.settings.clingStd)
             .onChange(async (value) => {
                 tab.plugin.settings.clingStd = value;
-                console.log('Cling std set to: ' + value);
+                console.log('gcc/Cling std set to: ' + value);
                 await tab.plugin.saveSettings();
             }));
     new Setting(containerEl)

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,276 @@
+/* @settings
+
+name: Execute Code Settings
+id: obsidian-execute-code
+settings:
+    -
+        id: color-section-title
+        title: Color Settings
+        type: heading
+        level: 3
+    -
+        id: use-custom-output-color
+        title: Custom Code Output Color
+        description: Use a custom color for the output of code blocks
+        type: class-toggle
+        default: false
+    -
+        id: code-output-text-color
+        title: Output Text Color
+        type: variable-color
+        format: hex
+        opacity: false
+        default: '#FFFFFF'
+    -
+        id: use-custom-error-color
+        title: Custom Code Error Color
+        description: Use a custom color for the error output of code blocks
+        type: class-toggle
+        default: false
+    -
+        id: code-error-text-color
+        title: Error Text Color
+        type: variable-color
+        format: hex
+        opacity: false
+        default: '#FF0000'
+*/
+
+button.run-code-button {
+	display: none;
+	color: var(--text-muted);
+	position: absolute;
+	bottom: 0;
+	right: 0;
+	margin: 5px;
+	padding: 5px 20px 5px 20px;
+	z-index: 100;
+}
+
+button.clear-button {
+	display: none;
+	color: var(--text-muted);
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	margin: 5px;
+	padding: 5px 20px 5px 20px;
+	z-index: 100;
+}
+
+pre:hover .run-code-button,
+pre:hover .clear-button {
+	display: block;
+}
+
+pre:hover .run-button-disabled,
+pre:hover .clear-button-disabled {
+	display: none;
+}
+
+.run-button-disabled,
+.clear-button-disabled {
+	display: none;
+}
+
+pre:hover code.language-output {
+	margin-bottom: 28px;
+}
+
+:not(.use-custom-output-color) code.language-output span.stdout {
+	color: var(--text-muted) !important;
+}
+
+.use-custom-output-color code.language-output span.stdout {
+	color: var(--code-output-text-color) !important;
+}
+
+:not(.use-custom-error-color) code.language-output span.stderr {
+	color: red !important;
+}
+
+.use-custom-error-color code.language-output span.stderr {
+	color: var(--code-error-text-color) !important;
+}
+
+code.language-output hr {
+	margin: 0 0 1em;
+}
+
+.settings-code-input-box textarea,
+.settings-code-input-box input {
+	min-width: 400px;
+	min-height: 100px;
+	font-family: monospace;
+	resize: vertical;
+}
+
+input.interactive-stdin {
+	font: inherit;
+}
+
+.manage-executors-view h3 {
+	margin: 1em;
+}
+
+.manage-executors-view ul {
+	margin: 1em;
+	padding: 0;
+	list-style-type: none;
+}
+
+.manage-executors-view ul li {
+	padding: 0.5em;
+	background: var(--background-primary-alt);
+	border-radius: 4px;
+	display: grid;
+	flex-direction: column;
+	margin-bottom: 0.5em;
+}
+
+.manage-executors-view small {
+	text-transform: uppercase;
+	font-weight: bold;
+	letter-spacing: 0.1ch;
+	grid-row: 1;
+}
+
+.manage-executors-view .filename {
+	grid-row: 2;
+}
+
+.manage-executors-view li button {
+	grid-column: 2;
+	grid-row: 1 / 3;
+	margin: 0;
+	padding: 0.25em;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--text-muted);
+	background: none;
+}
+
+.manage-executors-view li button:hover {
+	background: var(--background-tertiary);
+	color: var(--icon-color-hover);
+}
+
+.manage-executors-view>div {
+	position: relative;
+}
+
+.manage-executors-view .empty-state {
+	color: var(--text-muted);
+	padding: 0.5em;
+}
+
+.has-run-code-button {
+	position: relative;
+}
+
+.load-state-indicator {
+	position: absolute;
+	top: 0.1em;
+	left: -2em;
+	width: 2em;
+	height: 2em;
+	background: var(--background-primary-alt);
+	border-top-left-radius: 4px;
+	border-bottom-left-radius: 4px;
+	color: var(--tx1);
+	transform: translateX(2em);
+	transition: transform 0.25s, opacity 0.25s;
+	opacity: 0;
+	pointer-events: none;
+	cursor: pointer;
+}
+
+.load-state-indicator svg {
+	width: 1.5em;
+	height: 1.5em;
+	margin: 0.25em;
+}
+
+.load-state-indicator.visible {
+	transform: translateX(0);
+	opacity: 1;
+	pointer-events: all;
+}
+
+.load-state-indicator::before {
+	content: "";
+	box-shadow: -1em 0 1em -0.75em inset var(--background-modifier-box-shadow);
+	position: absolute;
+	display: block;
+	width: 100%;
+	height: 100%;
+	transform: translateX(-2em);
+	opacity: 0;
+	transition: transform 0.25s, opacity 0.25s;
+	pointer-events: none;
+}
+
+.load-state-indicator.visible::before {
+	transform: translateX(0);
+	opacity: 1;
+}
+
+/* Hide code blocks with language-output only in markdown view using "markdown-preview-view"*/
+.markdown-preview-view pre.language-output {
+	display: none;
+}
+
+.markdown-rendered pre.language-output {
+	display: none;
+}
+
+/* Do not hide code block when exporting to PDF */
+@media print {
+	pre.language-output {
+		display: block;
+	}
+
+	/* Hide code blocks with language-output only in markdown view using "markdown-preview-view"*/
+	.markdown-preview-view pre.language-output {
+		display: block;
+	}
+
+	.markdown-rendered pre.language-output {
+		display: block;
+	}
+}
+
+/* Center LaTeX vector graphics, confine to text width */
+.center-latex-figures img[src*="/figure%20"][src$=".svg"],
+.center-latex-figures img[src*="/figure%20"][src*=".svg?"],
+.center-latex-figures .stdout img[src*=".svg?"] {
+	display: block;
+	margin: auto;
+	max-width: 100%;
+}
+
+/* Invert LaTeX vector graphics in dark mode */
+.theme-dark.invert-latex-figures img[src*="/figure%20"][src$=".svg"],
+.theme-dark.invert-latex-figures img[src*="/figure%20"][src*=".svg?"],
+.theme-dark.invert-latex-figures .stdout img[src*=".svg?"] {
+	filter: invert(1);
+}
+
+/* Allow descriptions in LaTeX settings to be selected and copied. */
+.selectable-description-text {
+	-moz-user-select: text;
+	-khtml-user-select: text;
+	-webkit-user-select: text;
+	-ms-user-select: text;
+	user-select: text;
+}
+
+.insert-figure-icon {
+	margin-left: 0.5em;
+}
+
+/* Try to keep description of cmd arguments in LaTeX settings on the same line. */
+code.selectable-description-text {
+	white-space: nowrap;
+}


### PR DESCRIPTION
1.following  [that fork](https://github.com/raccoonhands1/obsidian-execute-code-enhanced) to support running cpp code via gcc.
2.add style.css to root path 
3.🤔i guess we need c# and cling test to make sure this won's break the old feature.
