### PR TITLE
Add Common Lisp support via SBCL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The result is shown only after the execution is finished. It is not possible to 
 
 <hr></div>
 
-The following [languages are supported](#supported-programming-languages-): C, C++, CSharp, Dart, F#, Golang, Groovy, Haskell, Java, JavaScript, Kotlin, Lean, Lua, Maxima, OCaml, Octave, Prolog, Python, R, Racket, Ruby, Rust, Scala, Shell (including Batch & Powershell), SQL, TypeScript, Wolfram Mathematica, Zig.
+The following [languages are supported](#supported-programming-languages-): C, C++, Common Lisp, CSharp, Dart, F#, Golang, Groovy, Haskell, Java, JavaScript, Kotlin, Lean, Lua, Maxima, OCaml, Octave, Prolog, Python, R, Racket, Ruby, Rust, Scala, Shell (including Batch & Powershell), SQL, TypeScript, Wolfram Mathematica, Zig.
 
 If you are new to MarkDown or Obsidian.md, you can go to the [Quickstart Guide](#quickstart-guide-) or take a look in to [some blogs and videos that feature this plugin](#featured-in)
 
@@ -525,6 +525,16 @@ println("Hello, World!")
 
 ```racket
 "Hello, world!"
+```
+</details>
+
+<details>
+<summary>Common Lisp</summary>
+
+- Requirements: SBCL is installed and the correct path is set in the settings.
+
+```lisp
+(format t "Hello, World!~%")
 ```
 </details>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
 	"name": "execute-code",
+	"version": "2.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "execute-code",
-			"version": "2.0.0",
+			"version": "2.1.2",
 			"license": "MIT",
 			"dependencies": {
 				"g": "^2.0.1",
@@ -4242,6 +4243,5 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		}
-	},
-	"version": "2.1.2"
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
 	"name": "execute-code",
-	"version": "2.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "execute-code",
-			"version": "2.1.2",
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"g": "^2.0.1",
@@ -4243,5 +4242,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		}
-	}
+	},
+	"version": "2.1.2"
 }

--- a/src/RunButton.ts
+++ b/src/RunButton.ts
@@ -72,6 +72,7 @@ async function handleExecution(block: CodeBlockContext) {
         case "octave": return runCode(s.octavePath, s.octaveArgs, s.octaveFileExtension, block, { shell: true, transform: (code) => macro.expandOctavePlot(code) });
         case "maxima": return runCode(s.maximaPath, s.maximaArgs, s.maximaFileExtension, block, { shell: true, transform: (code) => macro.expandMaximaPlot(code) });
         case "racket": return runCode(s.racketPath, s.racketArgs, s.racketFileExtension, block, { shell: true });
+        case "lisp": return runCode(s.lispPath, s.lispArgs, s.lispFileExtension, block, { shell: true });
         case "applescript": return runCode(s.applescriptPath, s.applescriptArgs, s.applescriptFileExtension, block, { shell: true });
         case "zig": return runCode(s.zigPath, s.zigArgs, "zig", block, { shell: true });
         case "ocaml": return runCode(s.ocamlPath, s.ocamlArgs, "ocaml", block, { shell: true });

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import * as runButton from './RunButton';
 export const languageAliases = ["javascript", "typescript", "bash", "csharp", "wolfram", "nb", "wl", "hs", "py", "tex"] as const;
 export const canonicalLanguages = ["js", "ts", "cs", "latex", "lean", "lua", "python", "cpp", "prolog", "shell", "groovy", "r",
 	"go", "rust", "java", "powershell", "kotlin", "mathematica", "haskell", "scala", "swift", "racket", "fsharp", "c", "dart",
-	"ruby", "batch", "sql", "octave", "maxima", "applescript", "zig", "ocaml", "php"] as const;
+	"ruby", "batch", "sql", "octave", "maxima", "applescript", "zig", "ocaml", "php", "lisp"] as const;
 export const supportedLanguages = [...languageAliases, ...canonicalLanguages] as const;
 export type LanguageId = typeof canonicalLanguages[number];
 

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -174,6 +174,10 @@ export interface ExecutorSettings {
 	ocamlPath: string;
 	ocamlArgs: string;
 	ocamlInject: string;
+	lispPath: string;
+	lispArgs: string;
+	lispFileExtension: string;
+	lispInject: string;
 
 	jsInteractive: boolean;
 	tsInteractive: boolean;
@@ -210,6 +214,7 @@ export interface ExecutorSettings {
 	zigInteractive: boolean;
 	ocamlInteractive: boolean;
 	phpInteractive: boolean;
+	lispInteractive: boolean;
 }
 
 
@@ -387,6 +392,10 @@ export const DEFAULT_SETTINGS: ExecutorSettings = {
 	phpArgs: "",
 	phpFileExtension: "php",
 	phpInject: "",
+	lispPath: "sbcl",
+	lispArgs: "--script",
+	lispFileExtension: "lisp",
+	lispInject: "",
 	jsInteractive: true,
 	tsInteractive: false,
 	csInteractive: false,
@@ -422,4 +431,5 @@ export const DEFAULT_SETTINGS: ExecutorSettings = {
 	zigInteractive: false,
 	ocamlInteractive: false,
 	phpInteractive: false,
+	lispInteractive: false,
 }

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -36,6 +36,7 @@ import makeApplescriptSettings from "./per-lang/makeApplescriptSettings";
 import makeZigSettings from "./per-lang/makeZigSettings";
 import makeOCamlSettings from "./per-lang/makeOCamlSettings";
 import makeSwiftSettings from "./per-lang/makeSwiftSettings";
+import makeLispSettings from "./per-lang/makeLispSettings";
 
 
 /**
@@ -162,6 +163,7 @@ export class SettingsTab extends PluginSettingTab {
 		makeScalaSettings(this, this.makeContainerFor("scala"));
 		makeSwiftSettings(this, this.makeContainerFor("swift"));
 		makeRacketSettings(this, this.makeContainerFor("racket"));
+		makeLispSettings(this, this.makeContainerFor("lisp"));
 		makeFSharpSettings(this, this.makeContainerFor("fsharp"));
 		makeRubySettings(this, this.makeContainerFor("ruby"));
 		makeSQLSettings(this, this.makeContainerFor("sql"));

--- a/src/settings/languageDisplayName.ts
+++ b/src/settings/languageDisplayName.ts
@@ -35,4 +35,5 @@ export const DISPLAY_NAMES: Record<LanguageId, string> = {
     applescript: "Applescript",
 	zig: "Zig",
 	ocaml: "OCaml",
+	lisp: "Common Lisp",
 } as const;

--- a/src/settings/per-lang/makeLispSettings.ts
+++ b/src/settings/per-lang/makeLispSettings.ts
@@ -1,0 +1,27 @@
+import { Setting } from "obsidian";
+import { SettingsTab } from "../SettingsTab";
+
+export default (tab: SettingsTab, containerEl: HTMLElement) => {
+    containerEl.createEl('h3', { text: 'Common Lisp Settings' });
+    new Setting(containerEl)
+        .setName('sbcl path')
+        .setDesc("Path to your sbcl installation")
+        .addText(text => text
+            .setValue(tab.plugin.settings.lispPath)
+            .onChange(async (value) => {
+                const sanitized = tab.sanitizePath(value);
+                tab.plugin.settings.lispPath = sanitized;
+                console.log('sbcl path set to: ' + sanitized);
+                await tab.plugin.saveSettings();
+            }));
+    new Setting(containerEl)
+        .setName('Common Lisp arguments')
+        .addText(text => text
+            .setValue(tab.plugin.settings.lispArgs)
+            .onChange(async (value) => {
+                tab.plugin.settings.lispArgs = value;
+                console.log('Common Lisp args set to: ' + value);
+                await tab.plugin.saveSettings();
+            }));
+    tab.makeInjectSetting(containerEl, "lisp");
+}


### PR DESCRIPTION
## Summary

Adds Common Lisp as a supported language, executed via [SBCL](https://www.sbcl.org/) (`sbcl --script`).

Code blocks tagged `lisp` get a run button and execute through the generic `NonInteractiveCodeExecutor`, following the same pattern as Racket:

```lisp
(format t "Hello, World!~%")
```

## Changes

- `src/main.ts` — add `lisp` to `canonicalLanguages`
- `src/settings/Settings.ts` — `lispPath`/`lispArgs`/`lispFileExtension`/`lispInject` + `lispInteractive`, with defaults `sbcl --script`, `.lisp` extension
- `src/settings/per-lang/makeLispSettings.ts` — new settings panel (mirrors `makeRacketSettings.ts`)
- `src/settings/SettingsTab.ts` — register the panel
- `src/settings/languageDisplayName.ts` — display name "Common Lisp"
- `src/RunButton.ts` — dispatch case for `lisp`
- `README.md` — language list + Common Lisp details block

## Testing

- `npm run build` passes (tsc typecheck + esbuild)
- Verified the exact spawned invocation locally: `sbcl --script <tempfile>.lisp` runs and prints output (SBCL 2.x via Homebrew, macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)