### PR TITLE
Make execution failures fail loudly: name the executable and exit code in the error Notice

### DIFF
--- a/src/executors/ClingExecutor.ts
+++ b/src/executors/ClingExecutor.ts
@@ -33,7 +33,7 @@ export default abstract class ClingExecutor extends NonInteractiveCodeExecutor {
 			const child = child_process.spawn(this.settings.clingPath, childArgs, {env: process.env, shell: this.usesShell});
 			// Set resolve callback to resolve the promise in the child_process.on('close', ...) listener from super.handleChildOutput
 			this.resolveRun = resolve;
-			this.handleChildOutput(child, outputter, this.tempFileId);
+			this.handleChildOutput(child, outputter, this.tempFileId, this.settings.clingPath);
 		});
 	}
 
@@ -41,8 +41,8 @@ export default abstract class ClingExecutor extends NonInteractiveCodeExecutor {
 	 * Run parent NonInteractiveCodeExecutor handleChildOutput logic, but replace temporary main function name
 	 * In all outputs from stdout and stderr callbacks, from temp_<id>() to main() to produce understandable output
 	 */
-	override async handleChildOutput(child: ChildProcessWithoutNullStreams, outputter: Outputter, fileName: string) {		
-		super.handleChildOutput(child, outputter, fileName);
+	override async handleChildOutput(child: ChildProcessWithoutNullStreams, outputter: Outputter, fileName: string, cmd?: string) {
+		super.handleChildOutput(child, outputter, fileName, cmd);
 		// Remove existing stdout and stderr callbacks
 		child.stdout.removeListener("data", this.stdoutCb);
 		child.stderr.removeListener("data", this.stderrCb);

--- a/src/executors/NonInteractiveCodeExecutor.ts
+++ b/src/executors/NonInteractiveCodeExecutor.ts
@@ -57,19 +57,19 @@ export default class NonInteractiveCodeExecutor extends Executor {
 
 					// compile c file with gcc and handle possible output
 					const childGCC = child_process.spawn(cmd, args, {env: process.env, shell: this.usesShell});
-					this.handleChildOutput(childGCC, outputter, tempFileName);
+					this.handleChildOutput(childGCC, outputter, tempFileName, cmd);
 					childGCC.on('exit', (code) => {
 						if (code === 0) {
 							// executing the compiled file
 							child = child_process.spawn(tempFileNameWExe, { env: process.env, shell: this.usesShell });
-							this.handleChildOutput(child, outputter, tempFileNameWExe).then(() => {
+							this.handleChildOutput(child, outputter, tempFileNameWExe, tempFileNameWExe).then(() => {
 								this.tempFileId = undefined; // Reset the file id to use a new file next time
 							});
 						}
 					});
 				} else {
 					child = child_process.spawn(cmd, args, { env: process.env, shell: this.usesShell });
-					this.handleChildOutput(child, outputter, tempFileName).then(() => {
+					this.handleChildOutput(child, outputter, tempFileName, cmd).then(() => {
 						this.tempFileId = undefined; // Reset the file id to use a new file next time
 					});
 				}				
@@ -105,7 +105,7 @@ export default class NonInteractiveCodeExecutor extends Executor {
 	 * @param fileName The name of the temporary file that was created for the code execution.
 	 * @returns a promise that will resolve when the child proces finishes
 	 */
-	protected async handleChildOutput(child: child_process.ChildProcessWithoutNullStreams, outputter: Outputter, fileName: string | undefined) {
+	protected async handleChildOutput(child: child_process.ChildProcessWithoutNullStreams, outputter: Outputter, fileName: string | undefined, cmd?: string) {
 		outputter.clear();
 
 		// Kill process on clear
@@ -129,8 +129,12 @@ export default class NonInteractiveCodeExecutor extends Executor {
 		});
 
 		child.on('close', (code) => {
-			if (code !== 0)
-				new Notice("Error!");
+			if (code === 127 || code === 126) {
+				// POSIX shells: 127 = command not found, 126 = found but not executable
+				new Notice(`Execute Code: ${cmd ? `'${cmd}'` : "the configured command"} ${code === 127 ? "was not found" : "is not executable"}. Set the full path to the executable in the plugin settings.`, 10000);
+			} else if (code !== 0) {
+				new Notice(`Execute Code: process exited with code ${code}. See the output below the code block.`);
+			}
 
 			// Resolve the run promise once finished running the code block
 			if (this.resolveRun !== undefined)
@@ -147,7 +151,7 @@ export default class NonInteractiveCodeExecutor extends Executor {
 		});
 
 		child.on('error', (err) => {
-			new Notice("Error!");
+			new Notice(`Execute Code: failed to start ${cmd ? `'${cmd}'` : "process"}: ${err.message}`, 10000);
 			outputter.writeErr(err.toString());
 		});
 	}

--- a/src/executors/PowerShellOnWindowsExecutor.ts
+++ b/src/executors/PowerShellOnWindowsExecutor.ts
@@ -47,7 +47,7 @@ export default class PowerShellOnWindowsExecutor extends NonInteractiveCodeExecu
 
 				const child = child_process.spawn(cmd, args, {env: process.env, shell: this.usesShell});
 
-				this.handleChildOutput(child, outputter, tempFileName).then(() => {
+				this.handleChildOutput(child, outputter, tempFileName, cmd).then(() => {
 					this.tempFileId = undefined; // Reset the file id to use a new file next time
 				});
 


### PR DESCRIPTION
## Summary

When a code block fails to run, the current toast just says **"Error!"** — and when the failure is "executable not on PATH" (very common on macOS, where GUI apps get the bare launchd PATH without Homebrew), the user gets no hint at what went wrong or how to fix it.

This PR makes `NonInteractiveCodeExecutor` failures actionable:

- Exit code **127 / 126** (POSIX: command not found / not executable) → `Execute Code: 'sbcl' was not found. Set the full path to the executable in the plugin settings.` (10s toast)
- Other non-zero exits → `Execute Code: process exited with code N. See the output below the code block.`
- Spawn `error` event (e.g. ENOENT when `shell: false`) → `Execute Code: failed to start 'cmd': <message>`

## Changes

- `handleChildOutput` gains an optional trailing `cmd?: string` param (backwards-compatible; callers that don't pass it get generic wording)
- Call sites in `NonInteractiveCodeExecutor` (incl. the gcc compile/execute path), `ClingExecutor`, and `PowerShellOnWindowsExecutor` pass the command through

## Testing

- `npm run build` passes (tsc + esbuild)
- Manually verified on macOS: a code block whose interpreter is a bare command not on Obsidian's PATH now shows the "was not found — set the full path" toast naming the executable; a block exiting non-zero shows the exit-code toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)