### PR TITLE
Persistent output: notify user once instead of console-spamming when the block can't be located

### DIFF
--- a/src/output/FileAppender.ts
+++ b/src/output/FileAppender.ts
@@ -1,10 +1,11 @@
-import { EditorPosition, EditorRange, MarkdownView } from "obsidian";
+import { EditorPosition, EditorRange, MarkdownView, Notice } from "obsidian";
 
 export default class FileAppender {
     view: MarkdownView;
     codeBlockElement: HTMLPreElement
     codeBlockRange: EditorRange
     outputPosition: EditorPosition;
+    notifiedUnsupported = false;
 
     public constructor(view: MarkdownView, blockElem: HTMLPreElement) {
         this.view = view;
@@ -14,7 +15,7 @@ export default class FileAppender {
         try {
             this.codeBlockRange = this.getRangeOfCodeBlock(blockElem);
         } catch (e) {
-            console.error("Error finding code block range: Probably because of 'run-' prefix");
+            console.warn("Execute Code: couldn't locate this code block in the editor ('run-' blocks and live preview aren't supported) — persistent output will not be saved for it.");
             this.codeBlockRange = null
         }
     }
@@ -41,8 +42,13 @@ export default class FileAppender {
         try {
             this.findOutputTarget();
         } catch (e) {
-            console.error("Error finding output target: Probably because of 'run-' prefix");
-            this.view.setViewData(this.view.editor.getValue(), false);
+            // Persistent output can't locate the code block in the editor for
+            // 'run-' prefixed blocks and live preview. Notify once per run
+            // instead of logging on every chunk of output.
+            if (!this.notifiedUnsupported) {
+                this.notifiedUnsupported = true;
+                new Notice("Execute Code: persistent output isn't supported for this code block ('run-' blocks and live preview) — the output is only shown below the block, not saved to the note.", 10000);
+            }
             return;
         }
 

--- a/src/output/FileAppender.ts
+++ b/src/output/FileAppender.ts
@@ -15,7 +15,11 @@ export default class FileAppender {
         try {
             this.codeBlockRange = this.getRangeOfCodeBlock(blockElem);
         } catch (e) {
-            console.warn("Execute Code: couldn't locate this code block in the editor ('run-' blocks and live preview aren't supported) — persistent output will not be saved for it.");
+            // Expected for 'run-' blocks and live preview; constructed at render
+            // time for every block, so don't log above debug level here. The
+            // user is notified in addOutput() if they actually run the block
+            // with persistent output enabled.
+            console.debug("Execute Code: couldn't locate this code block in the editor — persistent output will not be saved for it.");
             this.codeBlockRange = null
         }
     }

--- a/src/output/FileAppender.ts
+++ b/src/output/FileAppender.ts
@@ -25,6 +25,10 @@ export default class FileAppender {
     }
 
     public clearOutput() {
+        // Called at the start of each run — re-arm the unsupported-block notice
+        // so it shows once per run, not once per rendered block.
+        this.notifiedUnsupported = false;
+
         if (this.codeBlockRange && this.outputPosition) {
 
             const editor = this.view.editor;


### PR DESCRIPTION
## Summary

With **Persistent Output** enabled, running a `run-<lang>` block (or any block whose editor range can't be resolved, e.g. live preview) logs `Error finding output target: Probably because of 'run-' prefix` to the console **on every chunk of stdout**, while the user gets no visible indication that their output isn't being saved to the note.

This PR:

- Shows a single Notice per run explaining what happened: *"persistent output isn't supported for this code block ('run-' blocks and live preview) — the output is only shown below the block, not saved to the note."*
- Stops the per-chunk `console.error` spam, and removes the `setViewData(editor.getValue())` call in that error path (it rewrote the identical document on every output chunk)
- Downgrades the constructor-time range-lookup failure to a clearer `console.warn`

On-screen output behavior is unchanged.

## Testing

- `npm run build` passes (tsc + esbuild)
- Manually verified: with persistent output on, a `run-lisp` block now shows the Notice once and produces no per-chunk console errors; the happy path (block range resolved) is untouched by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
