### PR TITLE
Fix compounding code injection on repeated runs of the same block

### DIFF
--- a/src/RunButton.ts
+++ b/src/RunButton.ts
@@ -37,7 +37,10 @@ async function handleExecution(block: CodeBlockContext) {
     const s: ExecutorSettings = block.outputter.settings;
 
     button.className = disabledClass;
-    block.srcCode = await new CodeInjector(app, s, language).injectCode(srcCode);
+    // Run against a copy of the block context: the context is shared between
+    // runs of the same rendered block, so writing the injected code back into
+    // it would compound pre/post/import injections on every re-run.
+    block = { ...block, srcCode: await new CodeInjector(app, s, language).injectCode(srcCode) };
 
     switch (language) {
         case "js": return runCode(s.nodePath, s.nodeArgs, s.jsFileExtension, block, { transform: (code) => macro.expandJS(code) });


### PR DESCRIPTION
## Summary

`handleExecution` assigns the injected source back into the block's `CodeBlockContext` (`block.srcCode = await ...injectCode(srcCode)`). That context is shared between runs of the same rendered block (it's captured in the run button's click listener), so every re-run injects pre-/post-/import code **on top of the previous run's already-injected source**.

Reproduction: with a labeled block (`{label="x"}`) and a second block importing it (`{import="x"}`), click Run on the importing block N times without re-rendering the note → the imported code is included N times (visible as N repeated definition echoes in interactive mode, and N-fold side effects for non-idempotent imports).

A side effect of the stale mutation is that `CodeInjector.parseFile` can no longer match the block against the note's source on re-runs (it compares `srcCode` to the file's block content to find the block's own args), so the block's own `import`/`ignore` args are silently dropped from the second run onward.

## Fix

Run against a shallow copy of the context: `block = { ...block, srcCode: <injected> }`. The shared context is never mutated; `runCode`'s optional `transform` also operates on the copy.

## Testing

- `npm run build` passes
- Manually verified: repeated runs of an importing block now produce identical output each time (previously the imported definitions accumulated once per click)

🤖 Generated with [Claude Code](https://claude.com/claude-code)