### PR TITLE
Add 'Run code block under cursor' command

### DIFF
--- a/src/RunButton.ts
+++ b/src/RunButton.ts
@@ -1,4 +1,4 @@
-import { App, Workspace, MarkdownView } from 'obsidian';
+import { App, Workspace, MarkdownView, MarkdownPostProcessorContext } from 'obsidian';
 import ExecutorContainer from './ExecutorContainer';
 import { LanguageId, PluginContext, supportedLanguages } from './main';
 import { Outputter } from './output/Outputter';
@@ -108,9 +108,9 @@ export function addInOpenFiles(plugin: PluginContext) {
  * @param view The current markdown view
  * @param plugin Contains context needed for execution.
 */
-export function addToAllCodeBlocks(element: HTMLElement, file: string, view: MarkdownView, plugin: PluginContext) {
+export function addToAllCodeBlocks(element: HTMLElement, file: string, view: MarkdownView, plugin: PluginContext, ctx?: MarkdownPostProcessorContext) {
     Array.from(element.getElementsByTagName("code"))
-        .forEach((codeBlock: HTMLElement) => addToCodeBlock(codeBlock, file, view, plugin));
+        .forEach((codeBlock: HTMLElement) => addToCodeBlock(codeBlock, file, view, plugin, ctx));
 }
 
 /**
@@ -120,7 +120,7 @@ export function addToAllCodeBlocks(element: HTMLElement, file: string, view: Mar
  * @param view The current markdown view
  * @param plugin Contains context needed for execution.
  */
-function addToCodeBlock(codeBlock: HTMLElement, file: string, view: MarkdownView, plugin: PluginContext) {
+function addToCodeBlock(codeBlock: HTMLElement, file: string, view: MarkdownView, plugin: PluginContext, ctx?: MarkdownPostProcessorContext) {
     if (codeBlock.className.match(/^language-\{\w+/i)) {
         codeBlock.className = codeBlock.className.replace(/^language-\{(\w+)/i, "language-$1 {");
         codeBlock.parentElement.className = codeBlock.className;
@@ -145,7 +145,9 @@ function addToCodeBlock(codeBlock: HTMLElement, file: string, view: MarkdownView
     const hasBlockBeenButtonifiedAlready = parent.classList.contains(codeBlockHasButtonClass);
     if (!isLanguageSupported || hasBlockBeenButtonifiedAlready) return;
 
-    const outputter = new Outputter(codeBlock, plugin.settings, view, plugin.app, file);
+    // Section info must be fetched lazily: line numbers shift as the note is edited
+    const getSectionInfo = ctx ? () => ctx.getSectionInfo(pre) : null;
+    const outputter = new Outputter(codeBlock, plugin.settings, view, plugin.app, file, srcCode, getSectionInfo);
     parent.classList.add(codeBlockHasButtonClass);
     const button = createButton();
     pre.appendChild(button);
@@ -205,5 +207,6 @@ function runCode(cmd: string, cmdArgs: string, ext: string, block: CodeBlockCont
             block.outputter.closeInput();
             block.outputter.finishBlock();
         }
+        block.outputter.flushPersistentOutput();
     });
 }

--- a/src/RunButton.ts
+++ b/src/RunButton.ts
@@ -15,7 +15,7 @@ export const buttonClass: string = "run-code-button";
 export const disabledClass: string = "run-button-disabled";
 export const codeBlockHasButtonClass: string = "has-run-code-button";
 
-interface CodeBlockContext {
+export interface CodeBlockContext {
     srcCode: string;
     button: HTMLButtonElement;
     language: LanguageId;
@@ -29,7 +29,7 @@ interface CodeBlockContext {
  * Injects any required code, transforms the source if needed, and manages button state.
  * @param block Contains context needed for execution including source code, output handler, and UI elements
  */
-async function handleExecution(block: CodeBlockContext) {
+export async function handleExecution(block: CodeBlockContext) {
     const language: LanguageId = block.language;
     const button: HTMLButtonElement = block.button;
     const srcCode: string = block.srcCode;

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import ExecutorManagerView, {
 } from './ExecutorManagerView';
 
 import runAllCodeBlocks from './runAllCodeBlocks';
+import runBlockUnderCursor from './runBlockUnderCursor';
 import { ReleaseNoteModel } from "./ReleaseNoteModal";
 import * as runButton from './RunButton';
 
@@ -74,6 +75,15 @@ export default class ExecuteCodePlugin extends Plugin {
 			id: "run-all-code-blocks-in-file",
 			name: "Run all Code Blocks in Current File",
 			callback: () => runAllCodeBlocks(this.app.workspace)
+		})
+
+		this.addCommand({
+			id: "run-block-under-cursor",
+			name: "Run code block under cursor",
+			editorCallback: (editor, ctx) => {
+				if (ctx instanceof MarkdownView)
+					runBlockUnderCursor(context, editor, ctx);
+			}
 		})
 
 		if (!this.settings.releaseNote2_1_0wasShowed) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ export default class ExecuteCodePlugin extends Plugin {
 		}
 		runButton.addInOpenFiles(context);
 		this.registerMarkdownPostProcessor((element, _context) => {
-			runButton.addToAllCodeBlocks(element, _context.sourcePath, this.app.workspace.getActiveViewOfType(MarkdownView), context);
+			runButton.addToAllCodeBlocks(element, _context.sourcePath, this.app.workspace.getActiveViewOfType(MarkdownView), context, _context);
 		});
 
 		// live preview renderers

--- a/src/output/FileAppender.ts
+++ b/src/output/FileAppender.ts
@@ -1,10 +1,11 @@
-import { EditorPosition, EditorRange, MarkdownView } from "obsidian";
+import { EditorPosition, EditorRange, MarkdownView, Notice } from "obsidian";
 
 export default class FileAppender {
     view: MarkdownView;
     codeBlockElement: HTMLPreElement
     codeBlockRange: EditorRange
     outputPosition: EditorPosition;
+    notifiedUnsupported = false;
 
     public constructor(view: MarkdownView, blockElem: HTMLPreElement) {
         this.view = view;
@@ -14,7 +15,7 @@ export default class FileAppender {
         try {
             this.codeBlockRange = this.getRangeOfCodeBlock(blockElem);
         } catch (e) {
-            console.error("Error finding code block range: Probably because of 'run-' prefix");
+            console.warn("Execute Code: couldn't locate this code block in the editor ('run-' blocks and live preview aren't supported) — persistent output will not be saved for it.");
             this.codeBlockRange = null
         }
     }
@@ -41,8 +42,13 @@ export default class FileAppender {
         try {
             this.findOutputTarget();
         } catch (e) {
-            console.error("Error finding output target: Probably because of 'run-' prefix");
-            this.view.setViewData(this.view.editor.getValue(), false);
+            // Persistent output can't locate the code block in the editor for
+            // 'run-' prefixed blocks and live preview. Notify once per run
+            // instead of logging on every chunk of output.
+            if (!this.notifiedUnsupported) {
+                this.notifiedUnsupported = true;
+                new Notice("Execute Code: persistent output isn't supported for this code block ('run-' blocks and live preview) — the output is only shown below the block, not saved to the note.", 10000);
+            }
             return;
         }
 

--- a/src/output/FileAppender.ts
+++ b/src/output/FileAppender.ts
@@ -1,209 +1,152 @@
-import { EditorPosition, EditorRange, MarkdownView, Notice } from "obsidian";
+import { App, MarkdownPostProcessorContext, Notice, TFile } from "obsidian";
 
+/**
+ * Saves the output of a code block into the note itself, in an `output` code
+ * block right below the executed block (like org-babel's `#+RESULTS:`).
+ *
+ * Output is buffered while the block runs and written once when it finishes,
+ * via `Vault.process`, so it works in reading view, live preview and for
+ * `run-` prefixed blocks alike. Re-running a block replaces its previous
+ * output block instead of appending a new one.
+ */
 export default class FileAppender {
-    view: MarkdownView;
-    codeBlockElement: HTMLPreElement
-    codeBlockRange: EditorRange
-    outputPosition: EditorPosition;
+    app: App;
+    srcFile: string;
+    srcCode: string;
+    getSectionInfo: (() => { lineStart: number, lineEnd: number } | null) | null;
+    buffer: string;
     notifiedUnsupported = false;
 
-    public constructor(view: MarkdownView, blockElem: HTMLPreElement) {
-        this.view = view;
-
-        this.codeBlockElement = blockElem;
-
-        try {
-            this.codeBlockRange = this.getRangeOfCodeBlock(blockElem);
-        } catch (e) {
-            // Expected for 'run-' blocks and live preview; constructed at render
-            // time for every block, so don't log above debug level here. The
-            // user is notified in addOutput() if they actually run the block
-            // with persistent output enabled.
-            console.debug("Execute Code: couldn't locate this code block in the editor — persistent output will not be saved for it.");
-            this.codeBlockRange = null
-        }
+    /**
+     * @param app The Obsidian app
+     * @param srcFile Path of the note containing the code block
+     * @param srcCode The original source of the code block, as rendered. Used
+     * to locate the block inside the note when no section info is available.
+     * @param getSectionInfo Lazy accessor for the block's section info from
+     * the markdown post-processor context, or null when unavailable (e.g.
+     * blocks buttonified outside a post-processing pass).
+     */
+    public constructor(app: App, srcFile: string, srcCode: string, getSectionInfo: (() => { lineStart: number, lineEnd: number } | null) | null) {
+        this.app = app;
+        this.srcFile = srcFile;
+        this.srcCode = srcCode;
+        this.getSectionInfo = getSectionInfo;
+        this.buffer = "";
     }
 
+    /**
+     * Called when the outputter is cleared, i.e. at the start of each run and
+     * from the "Clear" button. Resets the run-scoped state.
+     */
     public clearOutput() {
-        // Called at the start of each run — re-arm the unsupported-block notice
-        // so it shows once per run, not once per rendered block.
+        this.buffer = "";
+        // Re-arm the not-saved notice so it shows once per run, not once per
+        // rendered block.
         this.notifiedUnsupported = false;
-
-        if (this.codeBlockRange && this.outputPosition) {
-
-            const editor = this.view.editor;
-
-            //Offset this.outputPosition by "\n```"
-            const afterEndOfOutputCodeBlock: EditorPosition = {
-                line: this.outputPosition.line + 1,
-                ch: "```".length + 1
-            };
-
-            editor.replaceRange("", this.codeBlockRange.to, afterEndOfOutputCodeBlock);
-            this.view.setViewData(editor.getValue(), false);
-
-            this.outputPosition = null;
-        }
     }
 
+    /**
+     * Buffers a segment of stdout data. No file I/O happens until `flush`.
+     */
     public addOutput(output: string) {
-        try {
-            this.findOutputTarget();
-        } catch (e) {
-            // Persistent output can't locate the code block in the editor for
-            // 'run-' prefixed blocks and live preview. Notify once per run
-            // instead of logging on every chunk of output.
-            if (!this.notifiedUnsupported) {
-                this.notifiedUnsupported = true;
-                new Notice("Execute Code: persistent output isn't supported for this code block ('run-' blocks and live preview) — the output is only shown below the block, not saved to the note.", 10000);
-            }
+        this.buffer += output;
+    }
+
+    /**
+     * Writes the buffered output into the note, replacing the code block's
+     * previous `output` block if it has one. Called once, when the code block
+     * finishes running.
+     */
+    public async flush() {
+        if (this.buffer === "") return;
+        const output = this.buffer;
+        this.buffer = "";
+
+        const file = this.app.vault.getAbstractFileByPath(this.srcFile);
+        if (!(file instanceof TFile)) {
+            this.notifyUnsupported();
             return;
         }
 
-        const editor = this.view.editor;
+        let located = true;
+        await this.app.vault.process(file, (data) => {
+            const blockEnd = this.findCodeBlockEnd(data);
+            if (blockEnd === null) {
+                located = false;
+                return data;
+            }
 
-        editor.replaceRange(output, this.outputPosition);
+            const sanitized = output.endsWith("\n") ? output : output + "\n";
+            const outputBlock = "```output\n" + sanitized + "```";
 
-        const lines = output.split("\n");
-        this.outputPosition = {
-            line: this.outputPosition.line + (lines.length - 1), //if the addition is only 1 line, don't change current line pos
-            ch: (lines.length == 1 ? //if the addition is only 1 line, then offset from the existing position.
-                this.outputPosition.ch : 0  //If it's not, ignore it.
-            ) + lines[lines.length - 1].length
-        }
+            // Replace an existing output block directly below the code block
+            const existing = data.slice(blockEnd).match(/^\n{1,2}```output\n[\s\S]*?\n?```(?=\n|$)/);
+            if (existing) {
+                const lineBreaks = existing[0].match(/^\n+/)[0];
+                return data.slice(0, blockEnd) + lineBreaks + outputBlock + data.slice(blockEnd + existing[0].length);
+            }
+            return data.slice(0, blockEnd) + "\n" + outputBlock + data.slice(blockEnd);
+        });
 
-        this.view.setViewData(this.view.editor.getValue(), false);
+        if (!located) this.notifyUnsupported();
+    }
+
+    private notifyUnsupported() {
+        if (this.notifiedUnsupported) return;
+        this.notifiedUnsupported = true;
+        new Notice("Execute Code: couldn't locate this code block in the note — the output is only shown below the block, not saved.", 10000);
     }
 
     /**
-     * Finds where output should be appended to and sets the `outputPosition` property to reflect it.
-     * @param addIfNotExist Add an `output` code block if one doesn't exist already
+     * Finds the offset just past the closing fence of this code block in the
+     * note's current content: from the renderer's section info if available,
+     * otherwise the first fenced block whose body matches the block's source.
+     * @param data The note's current content
+     * @returns the offset of the end of the closing fence, or null
      */
-    findOutputTarget(addIfNotExist = true) {
-        const editor = this.view.editor;
+    private findCodeBlockEnd(data: string): number | null {
+        const lines = data.split("\n");
 
-        const EXPECTED_SUFFIX = "\n```output\n";
-
-        const sigilEndIndex = editor.posToOffset(this.codeBlockRange.to) + EXPECTED_SUFFIX.length;
-
-        const outputBlockSigilRange: EditorRange = {
-            from: this.codeBlockRange.to,
-            to: {
-                ch: 0, //since the suffix ends with a newline, it'll be column 0
-                line: this.codeBlockRange.to.line + 2 // the suffix adds 2 lines
-            }
+        const section = this.getSectionInfo?.() ?? null;
+        if (section) {
+            const end = this.matchBlockInLines(lines, section.lineStart, Math.min(section.lineEnd, lines.length - 1));
+            if (end !== null) return end;
         }
-
-        const hasOutput = editor.getRange(outputBlockSigilRange.from, outputBlockSigilRange.to) == EXPECTED_SUFFIX;
-
-        if (hasOutput) {
-            //find the first code block end that occurs after the ```output sigil
-            const index = editor.getValue().indexOf("\n```\n", sigilEndIndex);
-
-            //bail out if we didn't find an end
-            if(index == -1) {
-                this.outputPosition = outputBlockSigilRange.to;
-            } else {
-                //subtract 1 so output appears before the newline
-                this.outputPosition = editor.offsetToPos(index - 1);
-            }
-        } else if (addIfNotExist) {
-            editor.replaceRange(EXPECTED_SUFFIX + "```\n", this.codeBlockRange.to);
-            this.view.data = this.view.editor.getValue();
-            //We need to recalculate the outputPosition because the insertion will've changed the lines.
-            //The expected suffix ends with a newline, so the column will always be 0;
-            //the row will be the current row + 2: the suffix adds 2 lines
-            this.outputPosition = {
-                ch: 0,
-                line: this.codeBlockRange.to.line + 2
-            };
-
-        } else {
-            this.outputPosition = outputBlockSigilRange.to;
-        }
+        return this.matchBlockInLines(lines, 0, lines.length - 1);
     }
 
     /**
-     * With a starting line, ending line, and number of codeblocks in-between those, find the exact EditorRange of a code block.
-     *
-     * @param startLine The line to start searching at
-     * @param endLine The line to end searching AFTER (i.e. it is inclusive)
-     * @param searchBlockIndex The index of code block, within the startLine-endLine range, to search for
-     * @returns an EditorRange representing the range occupied by the given block, or null if it couldn't be found
+     * Scans `lines[from..to]` for a fenced code block whose body equals this
+     * block's source code.
+     * @returns the offset just past the closing fence, or null
      */
-    findExactCodeBlockRange(startLine: number, endLine: number, searchBlockIndex: number): EditorRange | null {
-        const editor = this.view.editor;
-        const textContent = editor.getValue();
+    private matchBlockInLines(lines: string[], from: number, to: number): number | null {
+        const src = this.srcCode.endsWith("\n") ? this.srcCode.slice(0, -1) : this.srcCode;
+        const srcLines = src === "" ? [] : src.split("\n");
 
-        const startIndex = editor.posToOffset({ ch: 0, line: startLine });
-        const endIndex = editor.posToOffset({ ch: 0, line: endLine + 1 });
+        for (let i = from; i <= to; i++) {
+            const fence = lines[i].match(/^(\s*)(`{3,}|~{3,})/);
+            if (!fence) continue;
 
-        //Start the parsing with a given amount of padding.
-        //This helps us if the section begins directly with "```".
-        //At the end, it iterates through the padding again.
-        const PADDING = "\n\n\n\n\n";
+            const bodyStart = i + 1;
+            const bodyEnd = bodyStart + srcLines.length; // index of expected closing fence
+            if (bodyEnd > to) continue;
+            if (!lines[bodyEnd].trim().startsWith(fence[2].charAt(0).repeat(3))) continue;
 
-
-        /*
-         escaped: whether we are currently in an escape character
-         inBlock: whether we are currently inside a code block
-         last5: a rolling buffer of the last 5 characters.
-            It could technically work with 4, but it's easier to do 5
-            and it leaves open future advanced parsing.
-         blockStart: the start of the last code block we entered
-
-         */
-        let escaped, inBlock, blockI = 0, last5 = PADDING, blockStart
-        for (let i = startIndex; i < endIndex + PADDING.length; i++) {
-            const char = i < endIndex ? textContent[i] : PADDING[0];
-
-            last5 = last5.substring(1) + char;
-            if (escaped) {
-                escaped = false;
-                continue;
-            }
-            if (char == "\\") {
-                escaped = true;
-                continue;
-            }
-            if (last5.substring(0, 4) == "\n```") {
-                inBlock = !inBlock;
-                //If we are entering a block, set the block start
-                if (inBlock) {
-                    blockStart = i - 4;
-                } else {
-                    //if we're leaving a block, check if its index is the searched index
-                    if (blockI == searchBlockIndex) {
-                        return {
-                            from: this.view.editor.offsetToPos(blockStart),
-                            to: this.view.editor.offsetToPos(i)
-                        }
-                    } else {// if it isn't, just increase the block index
-                        blockI++;
-                    }
+            let matches = true;
+            for (let j = 0; j < srcLines.length; j++) {
+                if (lines[bodyStart + j] !== srcLines[j]) {
+                    matches = false;
+                    break;
                 }
             }
+            if (!matches) continue;
+
+            // Offset of the end of the closing fence line
+            let offset = 0;
+            for (let j = 0; j < bodyEnd; j++) offset += lines[j].length + 1;
+            return offset + lines[bodyEnd].length;
         }
         return null;
-    }
-
-    /**
-     * Uses an undocumented API to find the EditorRange that corresponds to a given codeblock's element.
-     * Returns null if it wasn't able to find the range.
-     * @param codeBlock <pre> element of the desired code block
-     * @returns the corresponding EditorRange, or null
-     */
-    getRangeOfCodeBlock(codeBlock: HTMLPreElement): EditorRange | null {
-        const parent = codeBlock.parentElement;
-        const index = Array.from(parent.children).indexOf(codeBlock);
-
-        //@ts-ignore
-        const section: null | { lineStart: number, lineEnd: number } = this.view.previewMode.renderer.sections.find(x => x.el == parent);
-
-        if (section) {
-            return this.findExactCodeBlockRange(section.lineStart, section.lineEnd, index);
-        } else {
-            return null;
-        }
     }
 }

--- a/src/output/FileAppender.ts
+++ b/src/output/FileAppender.ts
@@ -77,7 +77,10 @@ export default class FileAppender {
                 return data;
             }
 
-            const sanitized = output.endsWith("\n") ? output : output + "\n";
+            // Normalize: strip leading blank lines (REPL executors can emit a
+            // stray fresh-line at block start), ensure a trailing newline
+            let sanitized = output.replace(/^\n+/, "");
+            if (!sanitized.endsWith("\n")) sanitized += "\n";
             const outputBlock = "```output\n" + sanitized + "```";
 
             // Replace an existing output block directly below the code block

--- a/src/output/FileAppender.ts
+++ b/src/output/FileAppender.ts
@@ -15,7 +15,11 @@ export default class FileAppender {
         try {
             this.codeBlockRange = this.getRangeOfCodeBlock(blockElem);
         } catch (e) {
-            console.warn("Execute Code: couldn't locate this code block in the editor ('run-' blocks and live preview aren't supported) — persistent output will not be saved for it.");
+            // Expected for 'run-' blocks and live preview; constructed at render
+            // time for every block, so don't log above debug level here. The
+            // user is notified in addOutput() if they actually run the block
+            // with persistent output enabled.
+            console.debug("Execute Code: couldn't locate this code block in the editor — persistent output will not be saved for it.");
             this.codeBlockRange = null
         }
     }

--- a/src/output/FileAppender.ts
+++ b/src/output/FileAppender.ts
@@ -56,16 +56,17 @@ export default class FileAppender {
      * Writes the buffered output into the note, replacing the code block's
      * previous `output` block if it has one. Called once, when the code block
      * finishes running.
+     * @returns whether output was written into the note
      */
-    public async flush() {
-        if (this.buffer === "") return;
+    public async flush(): Promise<boolean> {
+        if (this.buffer === "") return false;
         const output = this.buffer;
         this.buffer = "";
 
         const file = this.app.vault.getAbstractFileByPath(this.srcFile);
         if (!(file instanceof TFile)) {
             this.notifyUnsupported();
-            return;
+            return false;
         }
 
         let located = true;
@@ -85,10 +86,11 @@ export default class FileAppender {
                 const lineBreaks = existing[0].match(/^\n+/)[0];
                 return data.slice(0, blockEnd) + lineBreaks + outputBlock + data.slice(blockEnd + existing[0].length);
             }
-            return data.slice(0, blockEnd) + "\n" + outputBlock + data.slice(blockEnd);
+            return data.slice(0, blockEnd) + "\n\n" + outputBlock + data.slice(blockEnd);
         });
 
         if (!located) this.notifyUnsupported();
+        return located;
     }
 
     private notifyUnsupported() {

--- a/src/output/FileAppender.ts
+++ b/src/output/FileAppender.ts
@@ -25,6 +25,10 @@ export default class FileAppender {
     }
 
     public clearOutput() {
+        // Called at the start of each run — re-arm the unsupported-block notice
+        // so it shows once per run, not once per rendered block.
+        this.notifiedUnsupported = false;
+
         if (this.codeBlockRange && this.outputPosition) {
 
             const editor = this.view.editor;

--- a/src/output/Outputter.ts
+++ b/src/output/Outputter.ts
@@ -53,10 +53,13 @@ export class Outputter extends EventEmitter {
 	/**
 	 * Writes the output buffered during this run into the note, if the
 	 * persistent output setting is enabled. Called when the block finishes.
+	 * When output was saved, the ephemeral on-screen output element is hidden —
+	 * the saved `output` block below the code block is the display.
 	 */
 	async flushPersistentOutput() {
-		if (this.settings.persistentOuput)
-			await this.saveToFile.flush();
+		if (!this.settings.persistentOuput) return;
+		if (await this.saveToFile.flush())
+			this.delete();
 	}
 
 	/**

--- a/src/output/Outputter.ts
+++ b/src/output/Outputter.ts
@@ -34,7 +34,7 @@ export class Outputter extends EventEmitter {
 	app: App;
 	srcFile: string;
 
-	constructor(codeBlock: HTMLElement, settings: ExecutorSettings, view: MarkdownView, app: App, srcFile: string) {
+	constructor(codeBlock: HTMLElement, settings: ExecutorSettings, view: MarkdownView, app: App, srcFile: string, srcCode: string, getSectionInfo: (() => { lineStart: number, lineEnd: number } | null) | null) {
 		super();
 		this.settings = settings;
 		this.app = app;
@@ -47,7 +47,16 @@ export class Outputter extends EventEmitter {
 		this.htmlBuffer = "";
 		this.blockRunState = "INITIAL";
 
-		this.saveToFile = new FileAppender(view, codeBlock.parentElement as HTMLPreElement);
+		this.saveToFile = new FileAppender(app, srcFile, srcCode, getSectionInfo);
+	}
+
+	/**
+	 * Writes the output buffered during this run into the note, if the
+	 * persistent output setting is enabled. Called when the block finishes.
+	 */
+	async flushPersistentOutput() {
+		if (this.settings.persistentOuput)
+			await this.saveToFile.flush();
 	}
 
 	/**

--- a/src/runBlockUnderCursor.ts
+++ b/src/runBlockUnderCursor.ts
@@ -1,0 +1,89 @@
+import { Editor, MarkdownView, Notice } from "obsidian";
+import type { PluginContext } from "./main";
+import { CodeBlockContext, handleExecution } from "./RunButton";
+import { Outputter } from "./output/Outputter";
+import { getLanguageAlias } from "./transforms/TransformCode";
+
+/**
+ * Runs the fenced code block containing the editor cursor (like org-babel's
+ * C-c C-c) and saves its output into the note below the block. Works entirely
+ * from the editor state — no rendered run button is needed — so it functions
+ * in source mode and live preview, even with the cursor inside the block.
+ */
+export default async function runBlockUnderCursor(plugin: PluginContext, editor: Editor, view: MarkdownView) {
+	if (!plugin.settings.persistentOuput) {
+		new Notice("Execute Code: \"Run code block under cursor\" writes its output into the note — enable Persistent Output in the plugin settings to use it.");
+		return;
+	}
+
+	const cursorLine = editor.getCursor().line;
+
+	// Track fence state from the top of the note to the cursor to find the
+	// block the cursor is inside (a fence line while a block is open closes
+	// it, except on the cursor's own line, which still counts as inside).
+	let openLine = -1;
+	let info = "";
+	for (let i = 0; i <= cursorLine; i++) {
+		const m = editor.getLine(i).match(/^\s*(`{3,}|~{3,})\s*(.*)$/);
+		if (!m) continue;
+		if (openLine === -1) {
+			openLine = i;
+			info = m[2].trim();
+		} else if (i < cursorLine) {
+			openLine = -1;
+			info = "";
+		}
+	}
+	if (openLine === -1) {
+		new Notice("Execute Code: no code block under the cursor.");
+		return;
+	}
+
+	// Find the closing fence
+	let endLine = -1;
+	for (let i = Math.max(cursorLine, openLine) + 1; i < editor.lineCount(); i++) {
+		if (editor.getLine(i).match(/^\s*(`{3,}|~{3,})\s*$/)) {
+			endLine = i;
+			break;
+		}
+	}
+	if (endLine === -1) {
+		new Notice("Execute Code: the code block under the cursor has no closing fence.");
+		return;
+	}
+
+	// Resolve the language from the fence info string, e.g. `lisp`,
+	// `run-python`, or `js {label="x"}`
+	let langToken = info.split(/[\s{]/)[0];
+	if (langToken.startsWith("run-")) langToken = langToken.substring("run-".length);
+	const language = getLanguageAlias(langToken);
+	if (language === undefined) {
+		new Notice(`Execute Code: "${langToken || "(none)"}" is not an executable code block language.`);
+		return;
+	}
+
+	const lines: string[] = [];
+	for (let i = openLine + 1; i < endLine; i++)
+		lines.push(editor.getLine(i));
+	const srcCode = lines.join("\n") + "\n";
+
+	// The outputter normally streams into an element under the block's
+	// rendered <pre>; when running from the editor there may be none (the
+	// cursor being inside the block unrenders it in live preview), so stream
+	// into a detached element and rely on the persistent output in the note.
+	const container = document.createElement("div");
+	const pre = container.appendChild(document.createElement("pre"));
+	const codeElem = pre.appendChild(document.createElement("code"));
+	const outputter = new Outputter(codeElem, plugin.settings, view, plugin.app, view.file.path, srcCode, null);
+
+	const block: CodeBlockContext = {
+		srcCode: srcCode,
+		language: language,
+		markdownFile: view.file.path,
+		button: document.createElement("button"),
+		outputter: outputter,
+		executors: plugin.executors,
+	};
+
+	await handleExecution(block);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -216,31 +216,6 @@ input.interactive-stdin {
 	opacity: 1;
 }
 
-/* Hide code blocks with language-output only in markdown view using "markdown-preview-view"*/
-.markdown-preview-view pre.language-output {
-	display: none;
-}
-
-.markdown-rendered pre.language-output {
-	display: none;
-}
-
-/* Do not hide code block when exporting to PDF */
-@media print {
-	pre.language-output {
-		display: block;
-	}
-
-	/* Hide code blocks with language-output only in markdown view using "markdown-preview-view"*/
-	.markdown-preview-view pre.language-output {
-		display: block;
-	}
-
-	.markdown-rendered pre.language-output {
-		display: block;
-	}
-}
-
 /* Center LaTeX vector graphics, confine to text width */
 .center-latex-figures img[src*="/figure%20"][src$=".svg"],
 .center-latex-figures img[src*="/figure%20"][src*=".svg?"],


### PR DESCRIPTION
## Summary

An editor command (like org-babel's `C-c C-c` / Jupyter's Ctrl-Enter): put the cursor anywhere inside a fenced code block in source mode or live preview and run it — no need to switch to reading view or hunt for the run button (which doesn't render in live preview while the cursor is inside the block). Output is saved into the note below the block via persistent output.

Builds on #449 (whose commits are included) — the buffered `Vault.process` persistent output is what lets this work without any rendered DOM.

## Implementation

- `runBlockUnderCursor.ts`: tracks fence state from the top of the note to the cursor to find the enclosing block (handles the cursor sitting on either fence line), resolves the language from the fence info string (including `run-` prefixes and `{...}` args), and dispatches through the existing `handleExecution` with a detached outputter element.
- `handleExecution` and `CodeBlockContext` are exported from `RunButton.ts`; no behavior change for the button path.
- Registered via `editorCallback`, so the command only offers itself when an editor is active.
- If Persistent Output is disabled, the command explains (via Notice) that it needs it — there is nowhere visible to stream output when running from the editor.

## Testing

- `npm run build` passes
- Verified in a live vault: cursor inside a `lisp` block in source mode → command executes it and writes/replaces the ```output block below; works with session (interactive) executors and the `run-` prefix; Notices for cursor-outside-block, unterminated fences, and non-executable languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)