### PR TITLE
Run button: play icon beside the copy button; always clear the load-state indicator

### DIFF
--- a/src/RunButton.ts
+++ b/src/RunButton.ts
@@ -1,4 +1,4 @@
-import { App, Workspace, MarkdownView } from 'obsidian';
+import { App, Workspace, MarkdownView, setIcon } from 'obsidian';
 import ExecutorContainer from './ExecutorContainer';
 import { LanguageId, PluginContext, supportedLanguages } from './main';
 import { Outputter } from './output/Outputter';
@@ -179,7 +179,8 @@ function createButton(): HTMLButtonElement {
     console.debug("Add run button");
     const button = document.createElement("button");
     button.classList.add(buttonClass);
-    button.setText(buttonText);
+    setIcon(button, "play");
+    button.setAttribute("aria-label", buttonText);
     return button;
 }
 
@@ -203,7 +204,10 @@ function runCode(cmd: string, cmdArgs: string, ext: string, block: CodeBlockCont
         block.button.className = buttonClass;
         if (!useShell) {
             block.outputter.closeInput();
-            block.outputter.finishBlock();
         }
+        // Always mark the block finished: interactive (REPL) executors call
+        // startBlock() themselves regardless of useShell, and a run that
+        // never clears its load-state indicator leaves a stuck spinner.
+        block.outputter.finishBlock();
     });
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -40,11 +40,22 @@ button.run-code-button {
 	display: none;
 	color: var(--text-muted);
 	position: absolute;
-	bottom: 0;
-	right: 0;
-	margin: 5px;
-	padding: 5px 20px 5px 20px;
+	top: var(--size-2-2, 4px);
+	right: var(--size-2-2, 4px);
+	margin: 0;
+	padding: var(--size-2-2, 4px) var(--size-2-3, 6px);
+	align-items: center;
+	justify-content: center;
 	z-index: 100;
+}
+
+button.run-code-button:hover {
+	color: var(--text-normal);
+}
+
+/* Shift the copy button left so the run button sits at the right edge */
+.has-run-code-button pre > button.copy-code-button {
+	right: calc(var(--size-2-2, 4px) + 2.4em);
 }
 
 button.clear-button {
@@ -58,7 +69,10 @@ button.clear-button {
 	z-index: 100;
 }
 
-pre:hover .run-code-button,
+pre:hover .run-code-button {
+	display: flex;
+}
+
 pre:hover .clear-button {
 	display: block;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -55,7 +55,7 @@ button.run-code-button:hover {
 
 /* Shift the copy button left so the run button sits at the right edge */
 .has-run-code-button pre > button.copy-code-button {
-	right: calc(var(--size-2-2, 4px) + 38px);
+	right: calc(var(--size-2-2, 4px) + 46px);
 }
 
 button.clear-button {

--- a/src/styles.css
+++ b/src/styles.css
@@ -55,7 +55,7 @@ button.run-code-button:hover {
 
 /* Shift the copy button left so the run button sits at the right edge */
 .has-run-code-button pre > button.copy-code-button {
-	right: calc(var(--size-2-2, 4px) + 2.4em);
+	right: calc(var(--size-2-2, 4px) + 38px);
 }
 
 button.clear-button {


### PR DESCRIPTION
## Summary

Two UI fixes:

1. **Run button placement.** The run button was a text button absolutely positioned at the bottom-right of the block, where it can collide with theme/plugin copy buttons. It's now a play icon (lucide, via `setIcon`) at the top right — matching Obsidian's own code-block affordances — with the built-in copy button shifted left to make room. `aria-label` preserves the "Run" name for accessibility.

2. **Stuck load-state indicator.** `runCode` only called `finishBlock()` when `useShell` was false, but interactive (REPL) executors call `startBlock()` themselves regardless of that flag. Any shell-invoked language backed by an interactive executor therefore left a permanently spinning load-state indicator (with its inset shadow) after every run. `finishBlock()` is now called unconditionally when the executor resolves; it's idempotent for the non-interactive path.

## Testing

- `npm run build` passes
- Verified in a live vault: play icon renders top-right with no overlap against the copy button (including with the Code Styler plugin active); after a session-mode block finishes, the indicator's `visible` class is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)